### PR TITLE
Updating travis for vim and bat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,18 @@ addons:
     packages:
       - git
       - zsh
+      - vim
+      - curl
+      - jq
+
+before_script:
+  - ln -s $TRAVIS_BUILD_DIR $HOME/.dotfiles # set up link for all my scripts
+  - mkdir -p ~/.i3 # make i3 dir for linking targets
+  - mkdir -p ~/.config # make dir for terminator
+  - U=$(curl https://github.cache.smirnov.cloud/repos/sharkdp/bat/releases/latest | jq -r -c 'first(.assets[] | select(.browser_download_url | contains("amd64"))) | .browser_download_url')
+  - wget $U # download bat.deb
+  - sudo dpkg -i $(basename $U) # install bat.
 
 script:
+  - ./install # test installation scipt. VIM, bat, etc.
   - cd zsh && if [[ $(grep -r '#!/bin/zsh' .) ]]; then echo "Found malformed shebangs"; exit 1;fi


### PR DESCRIPTION
- adding [sharkdp/bat](https://github.com/sharkdp/bat) and vim checks
- Note the interesting usage of [jq](https://stedolan.github.io/jq/) to extract the bat download URL