### PR TITLE
Update BAT_PAGER

### DIFF
--- a/bat/bat.conf
+++ b/bat/bat.conf
@@ -1,6 +1,6 @@
 # Add mouse scrolling support in less (does not work with older
 # versions of "less")
---pager="less -FR"
+--pager="less -FRXS"
 
 # Use "gitignore" highlighting for ".ignore" files
 --map-syntax .ignore:.gitignore

--- a/zsh/config/bat.zsh
+++ b/zsh/config/bat.zsh
@@ -3,4 +3,4 @@ export BAT_CONFIG_PATH="$HOME/.dotfiles/bat/bat.conf"
 
 # define pager. Note that even though this is defined in the 
 # bat config file, for some reason we still have to set it here.
-export BAT_PAGER="less -RF"
+export BAT_PAGER="less -RFXS"


### PR DESCRIPTION
There was a bug with "show" where files would be displayed as empty text. Drilling down I discovered that "less -FR" would quit out and show nothing if the file was less than one page long. Apparently adding -X and -S solves this issue.