### PR TITLE
Improve Ubersicht performance

### DIFF
--- a/ubersicht/left.jsx
+++ b/ubersicht/left.jsx
@@ -3,7 +3,7 @@ import Error from './lib/Error/index.jsx';
 import { leftSide } from './lib/style.jsx';
 import parse from './lib/parse.jsx';
 
-export const refreshFrequency = 100
+export const refreshFrequency = 1000000
 
 export const command = '/usr/local/bin/yabai -m query --spaces'
 

--- a/ubersicht/right.jsx
+++ b/ubersicht/right.jsx
@@ -1,14 +1,14 @@
 import DateTime from './lib/DateTime/index.jsx';
 import Battery from './lib/Battery/index.jsx';
 import Cpu from './lib/Cpu/index.jsx';
-import Memory from './lib/Memory/index.jsx';
+// import Memory from './lib/Memory/index.jsx';
 import Wifi from './lib/Wifi/index.jsx';
 import Weather from './lib/Weather/index.jsx';
 import Error from './lib/Error/index.jsx';
 import { rightSide } from './lib/style.jsx';
 import parse from './lib/parse.jsx';
 
-export const refreshFrequency = 100
+export const refreshFrequency = 2000
 
 export const command = './status-right.sh'
 

--- a/yabai/yabairc
+++ b/yabai/yabairc
@@ -40,4 +40,9 @@ yabai -m config left_padding                 20
 yabai -m config right_padding                20
 yabai -m config window_gap                   10
 
+
+# performance optimization
+yabai -m signal --add event=space_changed \
+    action="osascript -e 'tell application \"Übersicht\" to refresh widget id \"left-jsx\"'"
+
 echo "yabai configuration loaded.."


### PR DESCRIPTION
Ubersicht has been eating up twice as much energy on my macbook as Chrome (!!!). Initial experiments show that decreasing polling frequency have large improvements, and reduce energy usage from 78 to 1 on my hackintosh.

I can absolutely live with less frequent CPU indicator updates if it means my system doesn't die 3x a day. 