### PR TITLE
Pass file name to bat in s function

### DIFF
--- a/zsh/config/fzf.zsh
+++ b/zsh/config/fzf.zsh
@@ -157,9 +157,9 @@ s(){
   local margin=5 # number of lines above and below search result.
   local preview_cmd='search={};file=$(echo $search | cut -d':' -f 1 );'
   preview_cmd+="margin=$margin;" # Inject value into scope.
-  preview_cmd+='line=$(echo $search | cut -d':' -f 2 ); ext=$(echo $file(:e));'
+  preview_cmd+='line=$(echo $search | cut -d':' -f 2 );'
   preview_cmd+='tail -n +$(( $(( $line - $margin )) > 0 ? $(($line-$margin)) : 0)) $file | head -n $(($margin*2+1)) |'
-  preview_cmd+='bat --paging=never --color=always --style=plain --language=$ext --highlight-line $(($margin+1))'
+  preview_cmd+='bat --paging=never --color=always --style=full --file-name $file --highlight-line $(($margin+1))'
   local full=$(ag "$*" \
     | fzf --select-1 --exit-0 --preview-window up:$(($margin*2+1)) --height=60%  --preview $preview_cmd)
   local file="$(echo $full | awk -F: '{print $1}')"


### PR DESCRIPTION
We can give bat the file name instead of explicitly setting a language, thus we won't encounter `[bat error] unknown syntax` no more