### PR TITLE
fix word boundary match

### DIFF
--- a/zsh/config/grc.zsh
+++ b/zsh/config/grc.zsh
@@ -25,7 +25,7 @@ _grc_injector(){
 	    #  - whitespace
 	    #  - sudo
 	    # then check for existence of program (determined by grc file suffix) and make sure we don't infintely append to zsh BUFFER
-	    if [[ "$BUFFER" =~ "(^|[/\w\.]+/|sudo\s+)$progmatch(\s*|$)\s?" && ! "$BUFFER" =~ "grcat conf*" ]]; then
+	    if [[ "$BUFFER" =~ "(^|[/\w\.]+/|sudo\s+)\b$progmatch\b(\s*|$)" && ! "$BUFFER" =~ "grcat conf*" ]]; then
 		BUFFER=$(echo "$BUFFER" | sed ':a;N;$!ba;s/\n$//')" | grcat conf.$prog"
 		break
 	    fi


### PR DESCRIPTION
Fix issues where commands like `psql 1.1.1.1` would trigger `| grcat conf.ps` and break stuff.

We now use proper word boundary matching.