### PR TITLE
i3blocks: Claude/Codex usage + adaptive network blocklets

### DIFF
--- a/i3/blocklets/README.md
+++ b/i3/blocklets/README.md
@@ -1,0 +1,111 @@
+# i3blocks blocklets
+
+Scripts that render segments in the i3 bar via [i3blocks](https://github.com/vivien/i3blocks).
+The bar's `status_command` sets `SCRIPT_DIR=~/.dotfiles/i3/blocklets`, so each `[name]`
+block in [`../i3blocks.conf`](../i3blocks.conf) runs the matching script in this folder.
+Each script prints the i3blocks 3-line protocol — `full_text`, `short_text`, `color`
+(`#RRGGBB`); `markup=none` is set globally.
+
+Most files here are stock [i3blocks-contrib](https://github.com/vivien/i3blocks-contrib)
+scripts (`battery`, `cpu_usage`, `disk`, `memory`, `volume`, `iface`, `wifi`, …). The two
+documented below — `ai_usage` and `network` — are custom.
+
+> **Reload:** i3blocks only re-reads its config when the bar (re)starts. After editing
+> `i3blocks.conf`, run **`i3-msg restart`** (in-place; windows/workspaces preserved). A
+> plain `i3-msg reload` is *not* enough.
+
+## `ai_usage` — Claude Code & Codex usage
+
+One script, run twice via `instance`:
+
+```ini
+[claude_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=claude
+interval=1200
+
+[codex_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=codex
+interval=1200
+```
+
+Shows the rolling **5-hour** and **weekly** usage windows for each provider, verbose with
+reset countdowns and a weekly pace indicator:
+
+```
+CC 5h 10% 7d 67% ⚠️13 (3d4h)
+CX 5h 3%  wk 11% ✅
+```
+
+### Data source
+
+Reads the same private endpoints the official UIs use (Claude Code's `/usage`, Codex's
+`/status`):
+
+| Provider | Endpoint | OAuth token (read at runtime) |
+|----------|----------|-------------------------------|
+| Claude | `GET https://api.anthropic.com/api/oauth/usage` | `~/.claude/.credentials.json` → `.claudeAiOauth.accessToken` |
+| Codex  | `GET https://chatgpt.com/backend-api/wham/usage` | `~/.codex/auth.json` → `.tokens.access_token` (+ `.account_id`) |
+
+**No secrets live in this repo.** Tokens are read from `$HOME` at call time and never
+written here; the response is cached in `~/.cache/i3blocks-aiusage/<provider>.json`. The
+script **never refreshes** the OAuth token (read-only, so it can't race a live CLI
+session) and always exits 0 so a failure can't break the bar. On error / expiry it shows
+the last cached value dimmed gray, or `CC ?` / `CX ?` if there's nothing cached.
+
+Claude's endpoint returns sticky `429`s without a `User-Agent: claude-code/<ver>` header
+and shouldn't be polled faster than ~180s; the in-script cache TTL enforces that floor
+regardless of the configured `interval`.
+
+### Weekly pace indicator
+
+Goal: consume ~100% of the weekly quota evenly (≈1/7 per day) without running out early or
+leaving tokens unused. The block compares your actual weekly usage to where even pacing
+would put you right now (`expected = elapsed/window × 100`) and appends:
+
+| Token | Meaning |
+|-------|---------|
+| `⚠️N` | N points **ahead** of pace — burning hot, ease off or you'll run out early |
+| `🦥N` | N points **behind** — under-using, speed up |
+| `✅`  | on pace (within ±5 points) |
+
+Only the **weekly** window gets a pace token; the 5-hour window is a short rolling limit,
+not a consume-to-100% goal.
+
+### Color
+
+The segment color reflects the **worst window's raw utilization**: green `<70`, yellow
+`70–89`, red `≥90`. Color signals proximity to the hard limit; the emoji signals pace.
+
+## `network` — adaptive network indicator
+
+Single block (`[network]`, `interval=10`). Keys off the **default route**, so it ignores
+the host's many docker / veth / bridge interfaces:
+
+| State | Renders | Color |
+|-------|---------|-------|
+| Wired (preferred) | `LAN` | green |
+| Wi-Fi | `<SSID> <signal>%` | yellow (orange if signal `<40`) |
+| VPN (`tun*` / `wg*` / `tap*`) | `VPN` | cyan |
+| No default route | `no net` | red (urgent — exit 33) |
+
+SSID and signal come from `nmcli` (falling back to `iw`).
+
+## Tests
+
+Dependency-free bash harness (no `bats`/`shellcheck` required). Both custom scripts expose
+env-var seams (`AIUSAGE_CACHE_DIR`, `AIUSAGE_NO_FETCH`, `AIUSAGE_ROLLOUT_FILE`,
+`NET_TEST_IF`/`NET_TEST_WIRELESS`/`NET_TEST_SSID`/`NET_TEST_SIGNAL`) and hidden dispatch
+verbs (`__color`, `__reset`, `__pace`, `__render`, `__maprollout`) so every branch —
+thresholds, pace math, parsing, caching, fallbacks, all network states — is testable
+offline against synthetic fixtures (no live network or tokens needed).
+
+```sh
+bash tests/run.sh        # runs every tests/test_*.sh
+```
+
+## See also
+
+Design notes and rationale (exact endpoints, verified response shapes, alternatives
+considered): [`../docs/2026-05-31-usage-and-network-blocklets-design.md`](../docs/2026-05-31-usage-and-network-blocklets-design.md).

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -58,12 +58,95 @@ render_codex() {
   color=$(pct_color "$worst")
   printf '%s\n%s\n%s\n' "CX $seg5 $segw" "CX ${five}/${wk}" "$color"
 }
-main()          { :; }          # implemented in Task 5
+main() {
+  local provider="${BLOCK_INSTANCE:-claude}" ttl cache json
+  case "$provider" in codex) ttl=120;; *) ttl=180;; esac
+  mkdir -p "$CACHE_DIR"; cache="$CACHE_DIR/$provider.json"
+
+  # 1) fresh cache -> live color
+  if [ -f "$cache" ] && [ $(( $(date +%s) - $(stat -c %Y "$cache") )) -lt "$ttl" ]; then
+    "render_$provider" "$(cat "$cache")" && return 0
+  fi
+  # 2) fetch live; cache only on valid response
+  json=$("fetch_$provider")
+  if "validate_$provider" "$json"; then
+    printf '%s' "$json" > "$cache"
+    "render_$provider" "$json" && return 0
+  fi
+  # 3) fallbacks, rendered gray
+  if [ "$provider" = "codex" ] && json=$(codex_rollout_json) && [ -n "$json" ]; then
+    emit_dim "$json" && return 0
+  fi
+  if [ -f "$cache" ]; then emit_dim "$(cat "$cache")" && return 0; fi
+  # 4) nothing available
+  local l; l=$(label); printf '%s ?\n%s ?\n#888888\n' "$l" "$l"
+}
+
+CACHE_DIR="${AIUSAGE_CACHE_DIR:-$HOME/.cache/i3blocks-aiusage}"
+
+fetch_claude() {
+  [ -n "${AIUSAGE_NO_FETCH:-}" ] && return 1
+  local cred="$HOME/.claude/.credentials.json" token ver
+  [ -f "$cred" ] || return 1
+  token=$(jq -r '.claudeAiOauth.accessToken // empty' "$cred"); [ -z "$token" ] && return 1
+  ver=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1); ver=${ver:-2.1.159}
+  curl -sS --max-time 6 \
+    -H "Authorization: Bearer $token" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "User-Agent: claude-code/$ver" \
+    "https://api.anthropic.com/api/oauth/usage" 2>/dev/null
+}
+validate_claude() { jq -e '.five_hour.utilization' >/dev/null 2>&1 <<<"${1:-}"; }
+
+fetch_codex() {
+  [ -n "${AIUSAGE_NO_FETCH:-}" ] && return 1
+  local auth="$HOME/.codex/auth.json" token acct
+  [ -f "$auth" ] || return 1
+  token=$(jq -r '.tokens.access_token // empty' "$auth"); [ -z "$token" ] && return 1
+  acct=$(jq -r '.tokens.account_id // empty' "$auth")
+  curl -sS --max-time 6 \
+    -H "Authorization: Bearer $token" \
+    -H "ChatGPT-Account-Id: $acct" \
+    -H "User-Agent: codex-cli" \
+    "https://chatgpt.com/backend-api/wham/usage" 2>/dev/null
+}
+validate_codex() { jq -e '.rate_limit.primary_window.used_percent' >/dev/null 2>&1 <<<"${1:-}"; }
+
+# stdin: one rollout JSONL line -> stdout: wham-shaped JSON (or exit 1)
+map_rollout_line() {
+  jq -e -c '
+    .payload.rate_limits as $r
+    | select($r != null and $r.primary != null)
+    | def after($w): (if $w.resets_at then ($w.resets_at - now)
+                      elif $w.resets_in_seconds then $w.resets_in_seconds
+                      else 0 end | floor);
+      { rate_limit: {
+          primary_window:   { used_percent: $r.primary.used_percent,   reset_after_seconds: after($r.primary) },
+          secondary_window: { used_percent: $r.secondary.used_percent, reset_after_seconds: after($r.secondary) } } }
+  ' 2>/dev/null
+}
+
+codex_rollout_json() {
+  local f line
+  f=$(ls -t "$HOME"/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -1); [ -n "$f" ] || return 1
+  line=$(grep '"rate_limits"' "$f" 2>/dev/null | tail -1); [ -n "$line" ] || return 1
+  printf '%s' "$line" | map_rollout_line
+}
+
+label() { case "${BLOCK_INSTANCE:-claude}" in codex) echo "CX";; *) echo "CC";; esac; }
+
+# re-render the given JSON but force the color line to gray (stale/fallback marker)
+emit_dim() {
+  local out; out=$("render_${BLOCK_INSTANCE:-claude}" "$1") || return 1
+  printf '%s\n%s\n#888888\n' "$(sed -n 1p <<<"$out")" "$(sed -n 2p <<<"$out")"
+}
 
 # ---- dispatch ----
 case "${1:-}" in
   __color)  pct_color "${2:-0}"; exit 0 ;;
   __reset)  fmt_reset "${2:-0}"; exit 0 ;;
-  __render) "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
+  __render)     "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
+  __maprollout) map_rollout_line; exit $? ;;
   *)        main ;;
 esac

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -40,7 +40,24 @@ render_claude() {
   color=$(pct_color "$worst")
   printf '%s\n%s\n%s\n' "CC $seg5 $seg7" "CC ${five}/${sev}" "$color"
 }
-render_codex()  { return 1; }   # implemented in Task 4
+render_codex() {
+  local json=$1 five wk seg5 segw worst color r
+  five=$(jq -r '.rate_limit.primary_window.used_percent // empty'   <<<"$json"); five=${five%.*}
+  wk=$(jq -r   '.rate_limit.secondary_window.used_percent // empty' <<<"$json"); wk=${wk%.*}
+  { [ -z "$five" ] || [ -z "$wk" ]; } && return 1
+  seg5="5h ${five}%"; segw="wk ${wk}%"
+  if [ "$five" -ge 50 ]; then
+    r=$(jq -r '.rate_limit.primary_window.reset_after_seconds // empty' <<<"$json")
+    [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null && seg5="$seg5 ($(fmt_reset "$r"))"
+  fi
+  if [ "$wk" -ge 50 ]; then
+    r=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json")
+    [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null && segw="$segw ($(fmt_reset "$r"))"
+  fi
+  worst=$five; [ "$wk" -gt "$worst" ] && worst=$wk
+  color=$(pct_color "$worst")
+  printf '%s\n%s\n%s\n' "CX $seg5 $segw" "CX ${five}/${wk}" "$color"
+}
 main()          { :; }          # implemented in Task 5
 
 # ---- dispatch ----

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -26,16 +26,16 @@ fmt_reset() {
 render_claude() {
   local json=$1 now five sev seg5 seg7 worst color r ts
   now=$(date +%s)
-  five=$(jq -r '.five_hour.utilization // empty' <<<"$json"); five=${five%.*}
-  sev=$(jq -r '.seven_day.utilization // empty' <<<"$json"); sev=${sev%.*}
+  five=$(jq -r '.five_hour.utilization // empty' <<<"$json" 2>/dev/null); five=${five%.*}
+  sev=$(jq -r '.seven_day.utilization // empty' <<<"$json" 2>/dev/null); sev=${sev%.*}
   { [ -z "$five" ] || [ -z "$sev" ]; } && return 1
   seg5="5h ${five}%"; seg7="7d ${sev}%"
   if [ "$five" -ge 50 ]; then
-    ts=$(jq -r '.five_hour.resets_at // empty' <<<"$json")
+    ts=$(jq -r '.five_hour.resets_at // empty' <<<"$json" 2>/dev/null)
     [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg5="$seg5 ($(fmt_reset "$r"))"
   fi
   if [ "$sev" -ge 50 ]; then
-    ts=$(jq -r '.seven_day.resets_at // empty' <<<"$json")
+    ts=$(jq -r '.seven_day.resets_at // empty' <<<"$json" 2>/dev/null)
     [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg7="$seg7 ($(fmt_reset "$r"))"
   fi
   worst=$five; [ "$sev" -gt "$worst" ] && worst=$sev
@@ -44,16 +44,16 @@ render_claude() {
 }
 render_codex() {
   local json=$1 five wk seg5 segw worst color r
-  five=$(jq -r '.rate_limit.primary_window.used_percent // empty'   <<<"$json"); five=${five%.*}
-  wk=$(jq -r   '.rate_limit.secondary_window.used_percent // empty' <<<"$json"); wk=${wk%.*}
+  five=$(jq -r '.rate_limit.primary_window.used_percent // empty'   <<<"$json" 2>/dev/null); five=${five%.*}
+  wk=$(jq -r   '.rate_limit.secondary_window.used_percent // empty' <<<"$json" 2>/dev/null); wk=${wk%.*}
   { [ -z "$five" ] || [ -z "$wk" ]; } && return 1
   seg5="5h ${five}%"; segw="wk ${wk}%"
   if [ "$five" -ge 50 ]; then
-    r=$(jq -r '.rate_limit.primary_window.reset_after_seconds // empty' <<<"$json"); r=${r%.*}
+    r=$(jq -r '.rate_limit.primary_window.reset_after_seconds // empty' <<<"$json" 2>/dev/null); r=${r%.*}
     [ -n "$r" ] && [ "$r" -gt 0 ] && seg5="$seg5 ($(fmt_reset "$r"))"
   fi
   if [ "$wk" -ge 50 ]; then
-    r=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json"); r=${r%.*}
+    r=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json" 2>/dev/null); r=${r%.*}
     [ -n "$r" ] && [ "$r" -gt 0 ] && segw="$segw ($(fmt_reset "$r"))"
   fi
   worst=$five; [ "$wk" -gt "$worst" ] && worst=$wk

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -21,7 +21,25 @@ fmt_reset() {
   fi
 }
 
-render_claude() { return 1; }   # implemented in Task 3
+render_claude() {
+  local json=$1 now five sev seg5 seg7 worst color r ts
+  now=$(date +%s)
+  five=$(jq -r '.five_hour.utilization // empty' <<<"$json"); five=${five%.*}
+  sev=$(jq -r '.seven_day.utilization // empty' <<<"$json"); sev=${sev%.*}
+  { [ -z "$five" ] || [ -z "$sev" ]; } && return 1
+  seg5="5h ${five}%"; seg7="7d ${sev}%"
+  if [ "$five" -ge 50 ]; then
+    ts=$(jq -r '.five_hour.resets_at // empty' <<<"$json")
+    [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg5="$seg5 ($(fmt_reset "$r"))"
+  fi
+  if [ "$sev" -ge 50 ]; then
+    ts=$(jq -r '.seven_day.resets_at // empty' <<<"$json")
+    [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg7="$seg7 ($(fmt_reset "$r"))"
+  fi
+  worst=$five; [ "$sev" -gt "$worst" ] && worst=$sev
+  color=$(pct_color "$worst")
+  printf '%s\n%s\n%s\n' "CC $seg5 $seg7" "CC ${five}/${sev}" "$color"
+}
 render_codex()  { return 1; }   # implemented in Task 4
 main()          { :; }          # implemented in Task 5
 

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -23,25 +23,26 @@ fmt_reset() {
   fi
 }
 
-# Pace for the weekly window toward 100% by reset: compares actual usage to where
-# even (1/7-per-day) pacing would put you right now. Prints ↑N (ahead / burning hot),
-# ↓N (behind / under-using), or = (on pace); N = percentage points off pace. Empty
-# when no reset time is known. Args: used reset_epoch now week_seconds
-claude_pace() {
-  local used=$1 reset=$2 now=$3 week=$4 rem elapsed expected delta
-  [ -z "$reset" ] && return 0
-  rem=$(( reset - now )); [ "$rem" -lt 0 ] && rem=0; [ "$rem" -gt "$week" ] && rem=$week
-  elapsed=$(( week - rem ))
-  expected=$(( elapsed * 100 / week ))
+# Pace toward 100% over a usage window (the weekly limit). Compares actual usage to
+# where even (1/7-per-day) pacing would put you now, returning an emoji + the points
+# off pace: ⚠️N = N ahead (burning hot — ease off or you'll run out early), 🦥N = N
+# behind (under-using — speed up), ✅ = on pace (within ±tol). Empty when no reset time.
+# Args: used remaining_seconds window_seconds
+pace_sym() {
+  local used=$1 rem=$2 window=$3 elapsed expected delta tol=5
+  [ -z "$rem" ] && return 0
+  [ "$rem" -lt 0 ] && rem=0; [ "$rem" -gt "$window" ] && rem=$window
+  elapsed=$(( window - rem ))
+  expected=$(( elapsed * 100 / window ))
   delta=$(( used - expected ))
-  if   [ "$delta" -ge 1 ];  then echo "↑${delta}"
-  elif [ "$delta" -le -1 ]; then echo "↓$(( -delta ))"
-  else echo "="
+  if   [ "$delta" -gt "$tol" ];  then echo "⚠️${delta}"
+  elif [ "$delta" -lt "-$tol" ]; then echo "🦥$(( -delta ))"
+  else echo "✅"
   fi
 }
 
 render_claude() {
-  local json=$1 now five sev seg5 seg7 worst color r ts sev_reset pace
+  local json=$1 now five sev seg5 seg7 worst color r ts sev_reset rem7 pace
   now=$(date +%s)
   five=$(jq -r '.five_hour.utilization // empty' <<<"$json" 2>/dev/null); five=${five%.*}
   sev=$(jq -r '.seven_day.utilization // empty' <<<"$json" 2>/dev/null); sev=${sev%.*}
@@ -53,7 +54,8 @@ render_claude() {
   fi
   ts=$(jq -r '.seven_day.resets_at // empty' <<<"$json" 2>/dev/null)
   sev_reset=""; [ -n "$ts" ] && sev_reset=$(date -d "$ts" +%s 2>/dev/null)
-  pace=$(claude_pace "$sev" "$sev_reset" "$now" 604800)
+  rem7=""; [ -n "$sev_reset" ] && rem7=$(( sev_reset - now ))
+  pace=$(pace_sym "$sev" "$rem7" 604800)
   [ -n "$pace" ] && seg7="$seg7 $pace"
   if [ "$sev" -ge 50 ] && [ -n "$sev_reset" ]; then
     r=$(( sev_reset - now )); [ "$r" -gt 0 ] && seg7="$seg7 ($(fmt_reset "$r"))"
@@ -63,7 +65,7 @@ render_claude() {
   printf '%s\n%s\n%s\n' "CC $seg5 $seg7" "CC ${five}/${sev}" "$color"
 }
 render_codex() {
-  local json=$1 five wk seg5 segw worst color r
+  local json=$1 five wk seg5 segw worst color r wk_after wk_window pace
   five=$(jq -r '.rate_limit.primary_window.used_percent // empty'   <<<"$json" 2>/dev/null); five=${five%.*}
   wk=$(jq -r   '.rate_limit.secondary_window.used_percent // empty' <<<"$json" 2>/dev/null); wk=${wk%.*}
   { [ -z "$five" ] || [ -z "$wk" ]; } && return 1
@@ -72,9 +74,12 @@ render_codex() {
     r=$(jq -r '.rate_limit.primary_window.reset_after_seconds // empty' <<<"$json" 2>/dev/null); r=${r%.*}
     [ -n "$r" ] && [ "$r" -gt 0 ] && seg5="$seg5 ($(fmt_reset "$r"))"
   fi
-  if [ "$wk" -ge 50 ]; then
-    r=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json" 2>/dev/null); r=${r%.*}
-    [ -n "$r" ] && [ "$r" -gt 0 ] && segw="$segw ($(fmt_reset "$r"))"
+  wk_after=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json" 2>/dev/null); wk_after=${wk_after%.*}
+  wk_window=$(jq -r '.rate_limit.secondary_window.limit_window_seconds // empty' <<<"$json" 2>/dev/null); wk_window=${wk_window%.*}; wk_window=${wk_window:-604800}
+  pace=$(pace_sym "$wk" "$wk_after" "$wk_window")
+  [ -n "$pace" ] && segw="$segw $pace"
+  if [ "$wk" -ge 50 ] && [ -n "$wk_after" ] && [ "$wk_after" -gt 0 ]; then
+    segw="$segw ($(fmt_reset "$wk_after"))"
   fi
   worst=$five; [ "$wk" -gt "$worst" ] && worst=$wk
   color=$(pct_color "$worst")
@@ -173,7 +178,7 @@ emit_dim() {
 case "${1:-}" in
   __color)  pct_color "${2:-0}"; exit 0 ;;
   __reset)  fmt_reset "${2:-0}"; exit 0 ;;
-  __pace)   claude_pace "${2:-}" "${3:-}" "${4:-}" "${5:-604800}"; exit 0 ;;
+  __pace)   pace_sym "${2:-}" "${3:-}" "${4:-604800}"; exit 0 ;;
   __render)     "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
   __maprollout) map_rollout_line; exit $? ;;
   *)        main ;;

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -3,6 +3,7 @@
 # Provider via $BLOCK_INSTANCE (claude|codex). Reads OAuth tokens from $HOME at
 # runtime — contains NO secrets. Safe to commit to a public repo.
 set -u
+CACHE_DIR="${AIUSAGE_CACHE_DIR:-$HOME/.cache/i3blocks-aiusage}"
 
 pct_color() {
   local p=${1:-0}
@@ -17,7 +18,8 @@ fmt_reset() {
   d=$(( s / 86400 )); h=$(( (s % 86400) / 3600 )); m=$(( (s % 3600) / 60 ))
   if   [ "$d" -gt 0 ]; then echo "${d}d${h}h"
   elif [ "$h" -gt 0 ]; then echo "${h}h${m}m"
-  else                      echo "${m}m"
+  else
+    if [ "$m" -gt 0 ]; then echo "${m}m"; else echo "<1m"; fi
   fi
 }
 
@@ -47,12 +49,12 @@ render_codex() {
   { [ -z "$five" ] || [ -z "$wk" ]; } && return 1
   seg5="5h ${five}%"; segw="wk ${wk}%"
   if [ "$five" -ge 50 ]; then
-    r=$(jq -r '.rate_limit.primary_window.reset_after_seconds // empty' <<<"$json")
-    [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null && seg5="$seg5 ($(fmt_reset "$r"))"
+    r=$(jq -r '.rate_limit.primary_window.reset_after_seconds // empty' <<<"$json"); r=${r%.*}
+    [ -n "$r" ] && [ "$r" -gt 0 ] && seg5="$seg5 ($(fmt_reset "$r"))"
   fi
   if [ "$wk" -ge 50 ]; then
-    r=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json")
-    [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null && segw="$segw ($(fmt_reset "$r"))"
+    r=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json"); r=${r%.*}
+    [ -n "$r" ] && [ "$r" -gt 0 ] && segw="$segw ($(fmt_reset "$r"))"
   fi
   worst=$five; [ "$wk" -gt "$worst" ] && worst=$wk
   color=$(pct_color "$worst")
@@ -64,7 +66,8 @@ main() {
   mkdir -p "$CACHE_DIR"; cache="$CACHE_DIR/$provider.json"
 
   # 1) fresh cache -> live color
-  if [ -f "$cache" ] && [ $(( $(date +%s) - $(stat -c %Y "$cache") )) -lt "$ttl" ]; then
+  local mtime; mtime=$(stat -c %Y "$cache" 2>/dev/null)
+  if [ -n "$mtime" ] && [ $(( $(date +%s) - mtime )) -lt "$ttl" ]; then
     "render_$provider" "$(cat "$cache")" && return 0
   fi
   # 2) fetch live; cache only on valid response
@@ -81,8 +84,6 @@ main() {
   # 4) nothing available
   local l; l=$(label); printf '%s ?\n%s ?\n#888888\n' "$l" "$l"
 }
-
-CACHE_DIR="${AIUSAGE_CACHE_DIR:-$HOME/.cache/i3blocks-aiusage}"
 
 fetch_claude() {
   [ -n "${AIUSAGE_NO_FETCH:-}" ] && return 1
@@ -129,7 +130,12 @@ map_rollout_line() {
 
 codex_rollout_json() {
   local f line
-  f=$(ls -t "$HOME"/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -1); [ -n "$f" ] || return 1
+  if [ -n "${AIUSAGE_ROLLOUT_FILE:-}" ]; then
+    f="$AIUSAGE_ROLLOUT_FILE"
+  else
+    f=$(ls -t "$HOME"/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -1)
+  fi
+  [ -n "$f" ] || return 1
   line=$(grep '"rate_limits"' "$f" 2>/dev/null | tail -1); [ -n "$line" ] || return 1
   printf '%s' "$line" | map_rollout_line
 }
@@ -138,8 +144,9 @@ label() { case "${BLOCK_INSTANCE:-claude}" in codex) echo "CX";; *) echo "CC";; 
 
 # re-render the given JSON but force the color line to gray (stale/fallback marker)
 emit_dim() {
-  local out; out=$("render_${BLOCK_INSTANCE:-claude}" "$1") || return 1
-  printf '%s\n%s\n#888888\n' "$(sed -n 1p <<<"$out")" "$(sed -n 2p <<<"$out")"
+  local out l1 l2; out=$("render_${BLOCK_INSTANCE:-claude}" "$1") || return 1
+  { IFS= read -r l1; IFS= read -r l2; } <<<"$out"
+  printf '%s\n%s\n#888888\n' "$l1" "$l2"
 }
 
 # ---- dispatch ----

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -23,8 +23,25 @@ fmt_reset() {
   fi
 }
 
+# Pace for the weekly window toward 100% by reset: compares actual usage to where
+# even (1/7-per-day) pacing would put you right now. Prints ↑N (ahead / burning hot),
+# ↓N (behind / under-using), or = (on pace); N = percentage points off pace. Empty
+# when no reset time is known. Args: used reset_epoch now week_seconds
+claude_pace() {
+  local used=$1 reset=$2 now=$3 week=$4 rem elapsed expected delta
+  [ -z "$reset" ] && return 0
+  rem=$(( reset - now )); [ "$rem" -lt 0 ] && rem=0; [ "$rem" -gt "$week" ] && rem=$week
+  elapsed=$(( week - rem ))
+  expected=$(( elapsed * 100 / week ))
+  delta=$(( used - expected ))
+  if   [ "$delta" -ge 1 ];  then echo "↑${delta}"
+  elif [ "$delta" -le -1 ]; then echo "↓$(( -delta ))"
+  else echo "="
+  fi
+}
+
 render_claude() {
-  local json=$1 now five sev seg5 seg7 worst color r ts
+  local json=$1 now five sev seg5 seg7 worst color r ts sev_reset pace
   now=$(date +%s)
   five=$(jq -r '.five_hour.utilization // empty' <<<"$json" 2>/dev/null); five=${five%.*}
   sev=$(jq -r '.seven_day.utilization // empty' <<<"$json" 2>/dev/null); sev=${sev%.*}
@@ -34,9 +51,12 @@ render_claude() {
     ts=$(jq -r '.five_hour.resets_at // empty' <<<"$json" 2>/dev/null)
     [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg5="$seg5 ($(fmt_reset "$r"))"
   fi
-  if [ "$sev" -ge 50 ]; then
-    ts=$(jq -r '.seven_day.resets_at // empty' <<<"$json" 2>/dev/null)
-    [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg7="$seg7 ($(fmt_reset "$r"))"
+  ts=$(jq -r '.seven_day.resets_at // empty' <<<"$json" 2>/dev/null)
+  sev_reset=""; [ -n "$ts" ] && sev_reset=$(date -d "$ts" +%s 2>/dev/null)
+  pace=$(claude_pace "$sev" "$sev_reset" "$now" 604800)
+  [ -n "$pace" ] && seg7="$seg7 $pace"
+  if [ "$sev" -ge 50 ] && [ -n "$sev_reset" ]; then
+    r=$(( sev_reset - now )); [ "$r" -gt 0 ] && seg7="$seg7 ($(fmt_reset "$r"))"
   fi
   worst=$five; [ "$sev" -gt "$worst" ] && worst=$sev
   color=$(pct_color "$worst")
@@ -153,6 +173,7 @@ emit_dim() {
 case "${1:-}" in
   __color)  pct_color "${2:-0}"; exit 0 ;;
   __reset)  fmt_reset "${2:-0}"; exit 0 ;;
+  __pace)   claude_pace "${2:-}" "${3:-}" "${4:-}" "${5:-604800}"; exit 0 ;;
   __render)     "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
   __maprollout) map_rollout_line; exit $? ;;
   *)        main ;;

--- a/i3/blocklets/ai_usage
+++ b/i3/blocklets/ai_usage
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# i3blocks: Claude Code / Codex usage (5h + weekly), verbose with reset countdowns.
+# Provider via $BLOCK_INSTANCE (claude|codex). Reads OAuth tokens from $HOME at
+# runtime — contains NO secrets. Safe to commit to a public repo.
+set -u
+
+pct_color() {
+  local p=${1:-0}
+  if   [ "$p" -ge 90 ]; then echo "#FF1744"
+  elif [ "$p" -ge 70 ]; then echo "#FFD600"
+  else                       echo "#00C853"
+  fi
+}
+
+fmt_reset() {
+  local s=${1:-0} d h m
+  d=$(( s / 86400 )); h=$(( (s % 86400) / 3600 )); m=$(( (s % 3600) / 60 ))
+  if   [ "$d" -gt 0 ]; then echo "${d}d${h}h"
+  elif [ "$h" -gt 0 ]; then echo "${h}h${m}m"
+  else                      echo "${m}m"
+  fi
+}
+
+render_claude() { return 1; }   # implemented in Task 3
+render_codex()  { return 1; }   # implemented in Task 4
+main()          { :; }          # implemented in Task 5
+
+# ---- dispatch ----
+case "${1:-}" in
+  __color)  pct_color "${2:-0}"; exit 0 ;;
+  __reset)  fmt_reset "${2:-0}"; exit 0 ;;
+  __render) "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
+  *)        main ;;
+esac

--- a/i3/blocklets/network
+++ b/i3/blocklets/network
@@ -10,7 +10,7 @@ is_wireless() {
   if [ -n "${NET_TEST_WIRELESS+x}" ]; then [ "$NET_TEST_WIRELESS" = 1 ]
   else [ -d "/sys/class/net/$1/wireless" ]; fi
 }
-get_ssid()   { echo "${NET_TEST_SSID-$(nmcli -t -f active,ssid   dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}')}"; }
+get_ssid()   { echo "${NET_TEST_SSID-$(nmcli -t -f active,ssid dev wifi 2>/dev/null | sed -n 's/^yes://p' | sed 's/\\:/:/g' | head -1)}"; }
 get_signal() { echo "${NET_TEST_SIGNAL-$(nmcli -t -f active,signal dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}')}"; }
 
 IF=$(get_iface)
@@ -25,6 +25,7 @@ esac
 
 if is_wireless "$IF"; then
   ssid=$(get_ssid); sig=$(get_signal)
+  [[ "$sig" =~ ^[0-9]+$ ]] || sig=""
   [ -z "$ssid" ] && ssid="wifi"
   color="#FFD600"; [ -n "$sig" ] && [ "$sig" -lt 40 ] 2>/dev/null && color="#FF6D00"
   if [ -n "$sig" ]; then text="$ssid ${sig}%"; else text="$ssid"; fi

--- a/i3/blocklets/network
+++ b/i3/blocklets/network
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# i3blocks: adaptive network indicator. Keys off the default route so it ignores
+# docker/veth/bridge interfaces. Quiet on wired, loud (SSID+signal) on wifi,
+# urgent when down. Test seams: NET_TEST_IF / NET_TEST_WIRELESS / NET_TEST_SSID /
+# NET_TEST_SIGNAL (use the ${VAR-...} form so an empty value is honored).
+set -u
+
+get_iface()   { echo "${NET_TEST_IF-$(ip route show default 2>/dev/null | awk '/^default/{print $5; exit}')}"; }
+is_wireless() {
+  if [ -n "${NET_TEST_WIRELESS+x}" ]; then [ "$NET_TEST_WIRELESS" = 1 ]
+  else [ -d "/sys/class/net/$1/wireless" ]; fi
+}
+get_ssid()   { echo "${NET_TEST_SSID-$(nmcli -t -f active,ssid   dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}')}"; }
+get_signal() { echo "${NET_TEST_SIGNAL-$(nmcli -t -f active,signal dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}')}"; }
+
+IF=$(get_iface)
+
+if [ -z "$IF" ]; then
+  printf 'no net\nno net\n#FF1744\n'; exit 33   # i3blocks: exit 33 marks the block urgent
+fi
+
+case "$IF" in
+  tun*|wg*|tap*) printf 'VPN\nVPN\n#00B8D4\n'; exit 0 ;;
+esac
+
+if is_wireless "$IF"; then
+  ssid=$(get_ssid); sig=$(get_signal)
+  [ -z "$ssid" ] && ssid="wifi"
+  color="#FFD600"; [ -n "$sig" ] && [ "$sig" -lt 40 ] 2>/dev/null && color="#FF6D00"
+  if [ -n "$sig" ]; then text="$ssid ${sig}%"; else text="$ssid"; fi
+  printf '%s\n%s\n%s\n' "$text" "$text" "$color"; exit 0
+fi
+
+printf 'LAN\nLAN\n#00C853\n'; exit 0

--- a/i3/blocklets/tests/assert.sh
+++ b/i3/blocklets/tests/assert.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Minimal dependency-free assertion helpers. Source this from test_*.sh.
+pass=0; fail=0
+assert_eq() { # $1 desc  $2 expected  $3 actual
+  if [ "$2" = "$3" ]; then pass=$((pass+1));
+  else fail=$((fail+1)); printf 'FAIL - %s\n  expected: %q\n  actual:   %q\n' "$1" "$2" "$3"; fi
+}
+assert_contains() { # $1 desc  $2 needle  $3 haystack
+  case "$3" in
+    *"$2"*) pass=$((pass+1));;
+    *) fail=$((fail+1)); printf 'FAIL - %s\n  needle: %q\n  in:     %q\n' "$1" "$2" "$3";;
+  esac
+}
+finish() { printf '%d passed, %d failed\n' "$pass" "$fail"; [ "$fail" -eq 0 ]; }

--- a/i3/blocklets/tests/assert.sh
+++ b/i3/blocklets/tests/assert.sh
@@ -11,4 +11,10 @@ assert_contains() { # $1 desc  $2 needle  $3 haystack
     *) fail=$((fail+1)); printf 'FAIL - %s\n  needle: %q\n  in:     %q\n' "$1" "$2" "$3";;
   esac
 }
+assert_not_contains() { # $1 desc  $2 needle  $3 haystack
+  case "$3" in
+    *"$2"*) fail=$((fail+1)); printf 'FAIL - %s\n  unexpected: %q\n  in: %q\n' "$1" "$2" "$3";;
+    *) pass=$((pass+1));;
+  esac
+}
 finish() { printf '%d passed, %d failed\n' "$pass" "$fail"; [ "$fail" -eq 0 ]; }

--- a/i3/blocklets/tests/fixtures/claude_high.json
+++ b/i3/blocklets/tests/fixtures/claude_high.json
@@ -1,0 +1,4 @@
+{
+  "five_hour": { "utilization": 95.0 },
+  "seven_day": { "utilization": 20.0 }
+}

--- a/i3/blocklets/tests/fixtures/claude_usage.json
+++ b/i3/blocklets/tests/fixtures/claude_usage.json
@@ -1,5 +1,5 @@
 {
-  "five_hour": { "utilization": 38.0, "resets_at": "2026-05-31T23:59:00+00:00" },
+  "five_hour": { "utilization": 38.0, "resets_at": "2099-01-01T00:00:00+00:00" },
   "seven_day": { "utilization": 60.0, "resets_at": "2099-01-01T00:00:00+00:00" },
   "seven_day_opus": null,
   "seven_day_sonnet": { "utilization": 5.0, "resets_at": "2099-01-01T00:00:00+00:00" }

--- a/i3/blocklets/tests/fixtures/claude_usage.json
+++ b/i3/blocklets/tests/fixtures/claude_usage.json
@@ -1,0 +1,6 @@
+{
+  "five_hour": { "utilization": 38.0, "resets_at": "2026-05-31T23:59:00+00:00" },
+  "seven_day": { "utilization": 60.0, "resets_at": "2099-01-01T00:00:00+00:00" },
+  "seven_day_opus": null,
+  "seven_day_sonnet": { "utilization": 5.0, "resets_at": "2099-01-01T00:00:00+00:00" }
+}

--- a/i3/blocklets/tests/fixtures/codex_high.json
+++ b/i3/blocklets/tests/fixtures/codex_high.json
@@ -1,0 +1,7 @@
+{
+  "plan_type": "pro",
+  "rate_limit": {
+    "primary_window":   { "used_percent": 92, "reset_after_seconds": 7200 },
+    "secondary_window": { "used_percent": 8,  "reset_after_seconds": 559455 }
+  }
+}

--- a/i3/blocklets/tests/fixtures/codex_rollout_line.jsonl
+++ b/i3/blocklets/tests/fixtures/codex_rollout_line.jsonl
@@ -1,0 +1,1 @@
+{"type":"event_msg","payload":{"type":"token_count","info":{},"rate_limits":{"limit_id":"codex","plan_type":"pro","primary":{"used_percent":15.0,"window_minutes":300,"resets_at":1780277106},"secondary":{"used_percent":6.0,"window_minutes":10080,"resets_at":1780845892}}}}

--- a/i3/blocklets/tests/fixtures/codex_wham.json
+++ b/i3/blocklets/tests/fixtures/codex_wham.json
@@ -1,0 +1,8 @@
+{
+  "plan_type": "pro",
+  "rate_limit": {
+    "allowed": true, "limit_reached": false,
+    "primary_window":   { "used_percent": 10, "limit_window_seconds": 18000,  "reset_after_seconds": 8672,   "reset_at": 1780295110 },
+    "secondary_window": { "used_percent": 8,  "limit_window_seconds": 604800, "reset_after_seconds": 559455, "reset_at": 1780845893 }
+  }
+}

--- a/i3/blocklets/tests/run.sh
+++ b/i3/blocklets/tests/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")" || exit 1
+rc=0
+for t in test_*.sh; do
+  [ -e "$t" ] || continue
+  echo "== $t =="
+  bash "$t" || rc=1
+done
+exit $rc

--- a/i3/blocklets/tests/test_ai_fallback.sh
+++ b/i3/blocklets/tests/test_ai_fallback.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+TMP=$(mktemp -d); cp "$DIR/fixtures/claude_usage.json" "$TMP/claude.json"
+
+# fresh cache -> live color (green), real text
+out=$(AIUSAGE_CACHE_DIR="$TMP" BLOCK_INSTANCE=claude bash "$S")
+assert_eq       "fresh cache live color" "#00C853"   "$(sed -n 3p <<<"$out")"
+assert_contains "fresh cache text"       "CC 5h 38%" "$(sed -n 1p <<<"$out")"
+
+# stale cache + no fetch -> dim (gray) but text preserved
+touch -d '1 hour ago' "$TMP/claude.json"
+out=$(AIUSAGE_CACHE_DIR="$TMP" AIUSAGE_NO_FETCH=1 BLOCK_INSTANCE=claude bash "$S")
+assert_eq       "stale dim color"  "#888888"   "$(sed -n 3p <<<"$out")"
+assert_contains "stale text kept"  "CC 5h 38%" "$(sed -n 1p <<<"$out")"
+
+# no cache + no fetch -> "CC ?"
+TMP2=$(mktemp -d)
+out=$(AIUSAGE_CACHE_DIR="$TMP2" AIUSAGE_NO_FETCH=1 BLOCK_INSTANCE=claude bash "$S")
+assert_eq "no-data full"  "CC ?"    "$(sed -n 1p <<<"$out")"
+assert_eq "no-data color" "#888888" "$(sed -n 3p <<<"$out")"
+
+rm -rf "$TMP" "$TMP2"
+finish

--- a/i3/blocklets/tests/test_claude.sh
+++ b/i3/blocklets/tests/test_claude.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+out=$(BLOCK_INSTANCE=claude bash "$S" __render < "$DIR/fixtures/claude_usage.json")
+full=$(sed -n 1p <<<"$out"); short=$(sed -n 2p <<<"$out"); color=$(sed -n 3p <<<"$out")
+assert_contains "claude 5h no reset (<50)" "5h 38% 7d 60% (" "$full"
+assert_contains "claude 7d pct"            "7d 60%"          "$full"
+assert_eq       "claude short"             "CC 38/60"        "$short"
+assert_eq       "claude color worst=60"    "#00C853"         "$color"
+finish

--- a/i3/blocklets/tests/test_claude.sh
+++ b/i3/blocklets/tests/test_claude.sh
@@ -4,8 +4,8 @@ out=$(BLOCK_INSTANCE=claude bash "$S" __render < "$DIR/fixtures/claude_usage.jso
 full=$(sed -n 1p <<<"$out"); short=$(sed -n 2p <<<"$out"); color=$(sed -n 3p <<<"$out")
 assert_contains     "claude 5h pct shown"          "5h 38%"   "$full"
 assert_not_contains "claude 5h has no reset (<50)"  "38% ("    "$full"
-assert_contains     "claude 7d pace shown (far-future fixture clamps to ahead)" "7d 60% ↑60" "$full"
-assert_contains     "claude 7d reset paren follows pace"                        "↑60 ("      "$full"
+assert_contains     "claude 7d pace shown (far-future fixture clamps to ahead)" "7d 60% ⚠️60" "$full"
+assert_contains     "claude 7d reset paren follows pace"                        "⚠️60 ("      "$full"
 assert_contains "claude 7d pct"            "7d 60%"          "$full"
 assert_eq       "claude short"             "CC 38/60"        "$short"
 assert_eq       "claude color worst=60"    "#00C853"         "$color"

--- a/i3/blocklets/tests/test_claude.sh
+++ b/i3/blocklets/tests/test_claude.sh
@@ -2,8 +2,15 @@
 DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
 out=$(BLOCK_INSTANCE=claude bash "$S" __render < "$DIR/fixtures/claude_usage.json")
 full=$(sed -n 1p <<<"$out"); short=$(sed -n 2p <<<"$out"); color=$(sed -n 3p <<<"$out")
-assert_contains "claude 5h no reset (<50)" "5h 38% 7d 60% (" "$full"
+assert_contains     "claude 5h pct shown"          "5h 38%"   "$full"
+assert_not_contains "claude 5h has no reset (<50)"  "38% ("    "$full"
+assert_contains     "claude 7d reset shown (>=50)"  "7d 60% (" "$full"
 assert_contains "claude 7d pct"            "7d 60%"          "$full"
 assert_eq       "claude short"             "CC 38/60"        "$short"
 assert_eq       "claude color worst=60"    "#00C853"         "$color"
+# high utilization, no resets_at present -> red, no reset paren, no crash
+hi=$(BLOCK_INSTANCE=claude bash "$S" __render < "$DIR/fixtures/claude_high.json")
+assert_eq           "claude high full"     "CC 5h 95% 7d 20%" "$(sed -n 1p <<<"$hi")"
+assert_not_contains "claude high no paren"  "95% ("           "$(sed -n 1p <<<"$hi")"
+assert_eq           "claude high color red" "#FF1744"         "$(sed -n 3p <<<"$hi")"
 finish

--- a/i3/blocklets/tests/test_claude.sh
+++ b/i3/blocklets/tests/test_claude.sh
@@ -4,7 +4,8 @@ out=$(BLOCK_INSTANCE=claude bash "$S" __render < "$DIR/fixtures/claude_usage.jso
 full=$(sed -n 1p <<<"$out"); short=$(sed -n 2p <<<"$out"); color=$(sed -n 3p <<<"$out")
 assert_contains     "claude 5h pct shown"          "5h 38%"   "$full"
 assert_not_contains "claude 5h has no reset (<50)"  "38% ("    "$full"
-assert_contains     "claude 7d reset shown (>=50)"  "7d 60% (" "$full"
+assert_contains     "claude 7d pace shown (far-future fixture clamps to ahead)" "7d 60% ↑60" "$full"
+assert_contains     "claude 7d reset paren follows pace"                        "↑60 ("      "$full"
 assert_contains "claude 7d pct"            "7d 60%"          "$full"
 assert_eq       "claude short"             "CC 38/60"        "$short"
 assert_eq       "claude color worst=60"    "#00C853"         "$color"

--- a/i3/blocklets/tests/test_codex.sh
+++ b/i3/blocklets/tests/test_codex.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
 
-# normal: 10% / 8% -> green, no resets (<50)
+# normal: 10% / 8% -> green; wk is on pace (~7% expected) -> ✅; no resets (<50)
 out=$(BLOCK_INSTANCE=codex bash "$S" __render < "$DIR/fixtures/codex_wham.json")
-assert_eq "codex full"  "CX 5h 10% wk 8%" "$(sed -n 1p <<<"$out")"
+assert_eq "codex full"  "CX 5h 10% wk 8% ✅" "$(sed -n 1p <<<"$out")"
 assert_eq "codex short" "CX 10/8"         "$(sed -n 2p <<<"$out")"
 assert_eq "codex color" "#00C853"         "$(sed -n 3p <<<"$out")"
 
 # high: 92% with 2h reset -> red, reset shown (reset_after_seconds is deterministic)
 out=$(BLOCK_INSTANCE=codex bash "$S" __render < "$DIR/fixtures/codex_high.json")
-assert_eq "codex high full"  "CX 5h 92% (2h0m) wk 8%" "$(sed -n 1p <<<"$out")"
+assert_eq "codex high full"  "CX 5h 92% (2h0m) wk 8% ✅" "$(sed -n 1p <<<"$out")"
 assert_eq "codex high color" "#FF1744"                "$(sed -n 3p <<<"$out")"
 finish

--- a/i3/blocklets/tests/test_codex.sh
+++ b/i3/blocklets/tests/test_codex.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+
+# normal: 10% / 8% -> green, no resets (<50)
+out=$(BLOCK_INSTANCE=codex bash "$S" __render < "$DIR/fixtures/codex_wham.json")
+assert_eq "codex full"  "CX 5h 10% wk 8%" "$(sed -n 1p <<<"$out")"
+assert_eq "codex short" "CX 10/8"         "$(sed -n 2p <<<"$out")"
+assert_eq "codex color" "#00C853"         "$(sed -n 3p <<<"$out")"
+
+# high: 92% with 2h reset -> red, reset shown (reset_after_seconds is deterministic)
+out=$(BLOCK_INSTANCE=codex bash "$S" __render < "$DIR/fixtures/codex_high.json")
+assert_eq "codex high full"  "CX 5h 92% (2h0m) wk 8%" "$(sed -n 1p <<<"$out")"
+assert_eq "codex high color" "#FF1744"                "$(sed -n 3p <<<"$out")"
+finish

--- a/i3/blocklets/tests/test_codex_fallback.sh
+++ b/i3/blocklets/tests/test_codex_fallback.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+TMP=$(mktemp -d)
+# no cache, no network, but a rollout file is available -> gray render from rollout
+out=$(AIUSAGE_CACHE_DIR="$TMP" AIUSAGE_NO_FETCH=1 \
+      AIUSAGE_ROLLOUT_FILE="$DIR/fixtures/codex_rollout_line.jsonl" \
+      BLOCK_INSTANCE=codex bash "$S")
+assert_contains "codex rollout fallback text" "5h 15%" "$(sed -n 1p <<<"$out")"
+assert_eq       "codex rollout fallback gray" "#888888" "$(sed -n 3p <<<"$out")"
+rm -rf "$TMP"
+finish

--- a/i3/blocklets/tests/test_codex_rollout.sh
+++ b/i3/blocklets/tests/test_codex_rollout.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+mapped=$(bash "$S" __maprollout < "$DIR/fixtures/codex_rollout_line.jsonl")
+out=$(BLOCK_INSTANCE=codex bash "$S" __render <<<"$mapped")
+assert_contains "rollout 5h" "5h 15%" "$(sed -n 1p <<<"$out")"
+assert_contains "rollout wk" "wk 6%"  "$(sed -n 1p <<<"$out")"
+finish

--- a/i3/blocklets/tests/test_helpers.sh
+++ b/i3/blocklets/tests/test_helpers.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+assert_eq "color 38 green"  "#00C853" "$(bash "$S" __color 38)"
+assert_eq "color 69 green"  "#00C853" "$(bash "$S" __color 69)"
+assert_eq "color 70 yellow" "#FFD600" "$(bash "$S" __color 70)"
+assert_eq "color 89 yellow" "#FFD600" "$(bash "$S" __color 89)"
+assert_eq "color 90 red"    "#FF1744" "$(bash "$S" __color 90)"
+assert_eq "reset minutes"   "7m"      "$(bash "$S" __reset 420)"
+assert_eq "reset hours"     "4h2m"    "$(bash "$S" __reset 14520)"
+assert_eq "reset days"      "3d4h"    "$(bash "$S" __reset 273600)"
+finish

--- a/i3/blocklets/tests/test_network.sh
+++ b/i3/blocklets/tests/test_network.sh
@@ -25,4 +25,13 @@ assert_eq "wifi weak color" "#FF6D00" "$(sed -n 3p <<<"$out")"
 out=$(NET_TEST_IF=enp8s0f0 NET_TEST_WIRELESS=0 bash "$S")
 assert_eq "wired full"  "LAN"     "$(sed -n 1p <<<"$out")"
 assert_eq "wired color" "#00C853" "$(sed -n 3p <<<"$out")"
+
+# wireguard iface also classified as VPN
+out=$(NET_TEST_IF=wg0 bash "$S")
+assert_eq "vpn wg full"  "VPN"     "$(sed -n 1p <<<"$out")"
+assert_eq "vpn wg color" "#00B8D4" "$(sed -n 3p <<<"$out")"
+
+# wifi with empty SSID (hidden network) -> "wifi" fallback label
+out=$(NET_TEST_IF=wlo1 NET_TEST_WIRELESS=1 NET_TEST_SSID="" NET_TEST_SIGNAL=65 bash "$S")
+assert_eq "wifi hidden ssid" "wifi 65%" "$(sed -n 1p <<<"$out")"
 finish

--- a/i3/blocklets/tests/test_network.sh
+++ b/i3/blocklets/tests/test_network.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../network"
+
+# no default route -> urgent "no net"
+out=$(NET_TEST_IF= bash "$S"); ec=$?
+assert_eq "down full"  "no net"  "$(sed -n 1p <<<"$out")"
+assert_eq "down color" "#FF1744" "$(sed -n 3p <<<"$out")"
+assert_eq "down exit"  "33"      "$ec"
+
+# vpn iface
+out=$(NET_TEST_IF=tun0 bash "$S")
+assert_eq "vpn full"  "VPN"     "$(sed -n 1p <<<"$out")"
+assert_eq "vpn color" "#00B8D4" "$(sed -n 3p <<<"$out")"
+
+# wifi strong signal
+out=$(NET_TEST_IF=wlo1 NET_TEST_WIRELESS=1 NET_TEST_SSID="MyAP-5G" NET_TEST_SIGNAL=72 bash "$S")
+assert_eq "wifi full"  "MyAP-5G 72%" "$(sed -n 1p <<<"$out")"
+assert_eq "wifi color" "#FFD600"     "$(sed -n 3p <<<"$out")"
+
+# wifi weak signal -> orange
+out=$(NET_TEST_IF=wlo1 NET_TEST_WIRELESS=1 NET_TEST_SSID="Far" NET_TEST_SIGNAL=22 bash "$S")
+assert_eq "wifi weak color" "#FF6D00" "$(sed -n 3p <<<"$out")"
+
+# wired -> quiet LAN
+out=$(NET_TEST_IF=enp8s0f0 NET_TEST_WIRELESS=0 bash "$S")
+assert_eq "wired full"  "LAN"     "$(sed -n 1p <<<"$out")"
+assert_eq "wired color" "#00C853" "$(sed -n 3p <<<"$out")"
+finish

--- a/i3/blocklets/tests/test_pace.sh
+++ b/i3/blocklets/tests/test_pace.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
-# claude_pace <used> <reset_epoch> <now> <week_seconds>; week=604800 (7d)
-# ahead: 64% used, but half-week+ remaining puts even pace at ~54% -> +10
-assert_eq "pace ahead"     "↑10" "$(bash "$S" __pace 64 277200 0 604800)"
-# behind: 20% used with only 1 day left, even pace would be ~85% -> -65
-assert_eq "pace behind"    "↓65" "$(bash "$S" __pace 20 86400 0 604800)"
-# on pace: 50% used exactly halfway through the window
-assert_eq "pace on-pace"   "="   "$(bash "$S" __pace 50 302400 0 604800)"
-# boundary: 1 point over even pace still reads as ahead
-assert_eq "pace just ahead" "↑1" "$(bash "$S" __pace 51 302400 0 604800)"
-# no reset time -> no pace token (empty output)
-assert_eq "pace no reset"  ""    "$(bash "$S" __pace 50 '' 0 604800)"
-# reset already passed (rem clamped to 0) -> even pace is 100%, so 60% reads as behind 40
-assert_eq "pace past reset" "↓40" "$(bash "$S" __pace 60 -100 0 604800)"
+# pace_sym <used> <remaining_seconds> <window_seconds>; window=604800 (7d), tol=5
+# ahead: 64% used, ~3.2d remaining -> even pace ~54% -> +10 -> warning
+assert_eq "pace ahead"      "⚠️10" "$(bash "$S" __pace 64 277200 604800)"
+# behind: 20% used, 1d remaining -> even pace ~85% -> -65 -> sloth
+assert_eq "pace behind"     "🦥65" "$(bash "$S" __pace 20 86400 604800)"
+# on pace: 50% used exactly halfway through
+assert_eq "pace on-pace"    "✅"   "$(bash "$S" __pace 50 302400 604800)"
+# within tolerance (delta=3 <= tol=5) -> on pace
+assert_eq "pace within tol" "✅"   "$(bash "$S" __pace 53 302400 604800)"
+# just over tolerance (delta=6 > 5) -> warning
+assert_eq "pace just over"  "⚠️6"  "$(bash "$S" __pace 56 302400 604800)"
+# no remaining-time known -> no pace token (empty)
+assert_eq "pace no rem"     ""     "$(bash "$S" __pace 50 '' 604800)"
+# reset already passed (rem clamped to 0) -> even pace is 100%, 60% reads as behind 40
+assert_eq "pace past reset" "🦥40" "$(bash "$S" __pace 60 -100 604800)"
 finish

--- a/i3/blocklets/tests/test_pace.sh
+++ b/i3/blocklets/tests/test_pace.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+# claude_pace <used> <reset_epoch> <now> <week_seconds>; week=604800 (7d)
+# ahead: 64% used, but half-week+ remaining puts even pace at ~54% -> +10
+assert_eq "pace ahead"     "↑10" "$(bash "$S" __pace 64 277200 0 604800)"
+# behind: 20% used with only 1 day left, even pace would be ~85% -> -65
+assert_eq "pace behind"    "↓65" "$(bash "$S" __pace 20 86400 0 604800)"
+# on pace: 50% used exactly halfway through the window
+assert_eq "pace on-pace"   "="   "$(bash "$S" __pace 50 302400 0 604800)"
+# boundary: 1 point over even pace still reads as ahead
+assert_eq "pace just ahead" "↑1" "$(bash "$S" __pace 51 302400 0 604800)"
+# no reset time -> no pace token (empty output)
+assert_eq "pace no reset"  ""    "$(bash "$S" __pace 50 '' 0 604800)"
+# reset already passed (rem clamped to 0) -> even pace is 100%, so 60% reads as behind 40
+assert_eq "pace past reset" "↓40" "$(bash "$S" __pace 60 -100 0 604800)"
+finish

--- a/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
+++ b/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
@@ -55,15 +55,17 @@ each colors independently.
 - **Response fields:** `.five_hour.utilization` (float 0–100), `.five_hour.resets_at`
   (ISO-8601 string with offset), `.seven_day.utilization`, `.seven_day.resets_at`.
   (`.seven_day_opus` / `.seven_day_sonnet` exist but may be null — not displayed.)
-- **Renders:** `CC 5h 7% 7d 66% ↑12 (3d4h)`
-- **Weekly pace indicator** (7d window only): goal is to consume ~100% of the weekly
-  quota evenly (1/7 per day) without running out early or leaving tokens unused. Compute
-  the even-pace target `expected = (elapsed / 604800) * 100` where `elapsed = 604800 -
-  (resets_at - now)`, then `delta = utilization - expected`. Render a compact token after
-  the 7d percentage: `↑N` = N points **ahead** of pace (burning hot — ease off), `↓N` =
-  N points **behind** (under-using — room to ramp up), `=` = on pace. Shown whenever a 7d
-  reset time is known (independent of the ≥50% reset-countdown threshold). The 5h window
-  gets no pace indicator (it's a short rolling limit, not a consume-to-100% goal).
+- **Renders:** `CC 5h 10% 7d 67% ⚠️13 (3d4h)`
+- **Weekly pace indicator** (`pace_sym`, weekly window only): goal is to consume ~100% of
+  the weekly quota evenly (1/7 per day) without running out early or leaving tokens unused.
+  Compute the even-pace target `expected = (elapsed / window) * 100` where `elapsed =
+  window - remaining` (window = 604800s), then `delta = utilization - expected`, and render
+  an emoji + the points off pace after the weekly percentage: `⚠️N` = N points **ahead**
+  (burning hot — ease off or you'll run out early), `🦥N` = N points **behind** (under-using
+  — speed up), `✅` = on pace (within ±5). Shown whenever a weekly reset time is known
+  (independent of the ≥50% reset-countdown threshold). **Applies to both** the Claude 7d
+  window and the Codex weekly window. The short 5-hour windows get no pace indicator —
+  they're rolling limits, not consume-to-100% goals.
 
 ### Codex (`instance=codex`)
 
@@ -78,7 +80,7 @@ each colors independently.
   18000), `.rate_limit.secondary_window.used_percent` (weekly; 604800). Each window has
   `reset_after_seconds` (countdown) and `reset_at` (epoch seconds). This read does not
   consume model quota.
-- **Renders:** `CX 5h 10% wk 8%`
+- **Renders:** `CX 5h 3% wk 11% ✅` (weekly pace via the shared `pace_sym` — see above)
 - **Fallback (no network / 401):** newest `~/.codex/sessions/*/*/*/rollout-*.jsonl`, last
   line containing `"rate_limits"`, fields `.payload.rate_limits.primary.used_percent` /
   `.secondary.used_percent`. This is a lagging snapshot and `rate_limits` may be null in some

--- a/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
+++ b/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
@@ -55,7 +55,15 @@ each colors independently.
 - **Response fields:** `.five_hour.utilization` (float 0–100), `.five_hour.resets_at`
   (ISO-8601 string with offset), `.seven_day.utilization`, `.seven_day.resets_at`.
   (`.seven_day_opus` / `.seven_day_sonnet` exist but may be null — not displayed.)
-- **Renders:** `CC 5h 38% 7d 60% (3d4h)`
+- **Renders:** `CC 5h 7% 7d 66% ↑12 (3d4h)`
+- **Weekly pace indicator** (7d window only): goal is to consume ~100% of the weekly
+  quota evenly (1/7 per day) without running out early or leaving tokens unused. Compute
+  the even-pace target `expected = (elapsed / 604800) * 100` where `elapsed = 604800 -
+  (resets_at - now)`, then `delta = utilization - expected`. Render a compact token after
+  the 7d percentage: `↑N` = N points **ahead** of pace (burning hot — ease off), `↓N` =
+  N points **behind** (under-using — room to ramp up), `=` = on pace. Shown whenever a 7d
+  reset time is known (independent of the ≥50% reset-countdown threshold). The 5h window
+  gets no pace indicator (it's a short rolling limit, not a consume-to-100% goal).
 
 ### Codex (`instance=codex`)
 

--- a/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
+++ b/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
@@ -106,12 +106,12 @@ interval=10
 [claude_usage]
 command=$SCRIPT_DIR/ai_usage
 instance=claude
-interval=300
+interval=1200
 
 [codex_usage]
 command=$SCRIPT_DIR/ai_usage
 instance=codex
-interval=300
+interval=1200
 ```
 
 Inserted just before `[time]`, so the resulting bar order (left→right) is the existing

--- a/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
+++ b/i3/docs/2026-05-31-usage-and-network-blocklets-design.md
@@ -1,0 +1,177 @@
+# i3blocks: AI usage + adaptive network blocklets — design
+
+**Date:** 2026-05-31
+**Host:** hexane
+**Repo:** `issmirnov/dotfiles` (public) — scripts live in `i3/blocklets/`, wired via `i3/i3blocks.conf`
+
+## Goal
+
+Add two things to the hexane i3blocks bar:
+
+1. **AI usage** — Claude Code and Codex, each showing the rolling 5-hour window and
+   the longer (7-day / weekly) window, verbose with reset countdowns. Two adjacent blocks.
+2. **Network** — one adaptive block: quiet on wired LAN, loud (SSID + signal) on wifi,
+   urgent when the link is down. Replaces the old `iface`/`wifi` blocklets, which are not
+   wired into the active config (the reason the indicator feels stale/absent).
+
+**Hard constraint:** the dotfiles repo is public. Committed scripts must contain **no
+secrets**. OAuth tokens are read at runtime from files under `$HOME` that live outside the
+repo; cache files live under `~/.cache/`.
+
+## Data-source decision
+
+Both providers expose the authoritative usage windows through the same private HTTP
+endpoints their own UIs call (`/usage` in Claude Code, `/status` in Codex). Both were
+**verified returning live data on hexane** during research.
+
+Alternatives rejected:
+
+- **Local-log estimate** (ccusage / Codex rollout JSONL): only estimates tokens/cost from
+  local logs; cannot report the official percentages and under-reports usage incurred from
+  the web app or other machines.
+- **Cache the statusline payload** (have `statusline-command.sh` persist `rate_limits`): the
+  payload is frequently absent for Max OAuth accounts (claude-code#40094) and is empty when
+  no session is running — defeats a standalone block.
+
+Used as a documented **fallback only** for Codex: the newest on-disk rollout snapshot.
+
+## Component 1 — `blocklets/ai_usage`
+
+One script, invoked twice via i3blocks `instance`, branching on `$BLOCK_INSTANCE`. Two
+separate blocks (not one combined) so a failure in one provider never blanks the other and
+each colors independently.
+
+### Claude (`instance=claude`)
+
+- **Request:** `GET https://api.anthropic.com/api/oauth/usage`
+- **Token:** `jq -r '.claudeAiOauth.accessToken' ~/.claude/.credentials.json`
+- **Headers (all required):**
+  - `Authorization: Bearer <token>`
+  - `anthropic-beta: oauth-2025-04-20`
+  - `anthropic-version: 2023-06-01`
+  - `User-Agent: claude-code/<ver>` — **load-bearing**; without it the endpoint returns
+    sticky HTTP 429. Derive `<ver>` from `claude --version` (regex `[0-9]+\.[0-9]+\.[0-9]+`),
+    fall back to a hardcoded recent version string.
+- **Response fields:** `.five_hour.utilization` (float 0–100), `.five_hour.resets_at`
+  (ISO-8601 string with offset), `.seven_day.utilization`, `.seven_day.resets_at`.
+  (`.seven_day_opus` / `.seven_day_sonnet` exist but may be null — not displayed.)
+- **Renders:** `CC 5h 38% 7d 60% (3d4h)`
+
+### Codex (`instance=codex`)
+
+- **Request:** `GET https://chatgpt.com/backend-api/wham/usage`
+- **Token:** `jq -r '.tokens.access_token' ~/.codex/auth.json`;
+  **account:** `jq -r '.tokens.account_id' ~/.codex/auth.json`
+- **Headers:**
+  - `Authorization: Bearer <token>`
+  - `ChatGPT-Account-Id: <account_id>`
+  - `User-Agent: codex-cli`
+- **Response fields:** `.rate_limit.primary_window.used_percent` (5h; `limit_window_seconds`
+  18000), `.rate_limit.secondary_window.used_percent` (weekly; 604800). Each window has
+  `reset_after_seconds` (countdown) and `reset_at` (epoch seconds). This read does not
+  consume model quota.
+- **Renders:** `CX 5h 10% wk 8%`
+- **Fallback (no network / 401):** newest `~/.codex/sessions/*/*/*/rollout-*.jsonl`, last
+  line containing `"rate_limits"`, fields `.payload.rate_limits.primary.used_percent` /
+  `.secondary.used_percent`. This is a lagging snapshot and `rate_limits` may be null in some
+  versions — scan backward and skip nulls; tolerate `resets_in_seconds` vs `resets_at` drift.
+
+### Shared logic
+
+- **Cache:** `~/.cache/i3blocks-aiusage/<provider>.json`. Render from cache when its mtime is
+  within TTL (**Claude 180 s** — a hard floor on polling; Codex 120 s). Only hit the network
+  when the cache is stale. This keeps Claude under its safe polling rate even if the block is
+  signalled to refresh.
+- **Color** (3rd output line; `markup=none` is set globally so color comes from this line,
+  not pango): driven by the worst of that provider's two windows —
+  green `#00C853` `<70`, yellow `#FFD600` `70–89`, red `#FF1744` `≥90`.
+- **Reset countdown:** appended in parentheses per window that is `≥50%`, e.g. `(3d4h)`,
+  `(4h2m)`, `(7m)`. Claude: parse ISO with `date -d`. Codex: use `reset_after_seconds`.
+- **Failure handling** (any of: missing token file / curl error / non-2xx / 401-expired),
+  in precedence order, all rendered in **gray `#888888`** to signal "not live":
+  1. For Codex only: the newest on-disk rollout snapshot (above).
+  2. The last cached value, regardless of age.
+  3. If neither exists: `CC ?` / `CX ?`.
+
+  The script **never refreshes the OAuth token** (a refresh rotates the token file and would
+  race a live Claude session, invalidating it). The script always exits 0 so it can never
+  break the bar.
+
+### Config (`i3/i3blocks.conf`)
+
+```ini
+[network]
+interval=10
+
+[claude_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=claude
+interval=300
+
+[codex_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=codex
+interval=300
+```
+
+Inserted just before `[time]`, so the resulting bar order (left→right) is the existing
+`bt_vol, memory, cpu_usage, volume`, then `network, claude_usage, codex_usage`, then `time`.
+`~/.i3blocks.conf` is a symlink to `i3/i3blocks.conf`, so editing the repo file is the
+deployed change (no separate dotbot relink needed).
+
+## Component 2 — `blocklets/network`
+
+Keys off the **default route**, which sidesteps the ~60 docker/veth/bridge interfaces on
+this host:
+
+```sh
+IF=$(ip route show default 2>/dev/null | awk '/^default/{print $5; exit}')
+```
+
+Decision tree:
+
+1. **No `$IF`** (no default route) → `no net`, red `#FF1744`, **exit 33** (i3blocks urgent).
+   Exit-33-as-urgent to be confirmed against installed i3blocks 1.5 during implementation; red
+   color is the baseline regardless.
+2. **`$IF` is `tun*`/`wg*`/`tap*`** → `VPN`, cyan `#00B8D4`. (A separate openvpn block exists;
+   this only prevents a tunnel being mislabeled "LAN".)
+3. **`/sys/class/net/$IF/wireless` exists** → **wifi** (the exception state — loud):
+   - SSID: `nmcli -t -f active,ssid dev wifi | awk -F: '$1=="yes"{print $2; exit}'`
+     (fallback `iw dev "$IF" link`). Handle the rare colon-in-SSID nmcli escaping.
+   - Signal 0–100: `nmcli -t -f active,signal dev wifi | awk -F: '$1=="yes"{print $2; exit}'`.
+   - Render `MyAP-5G 72%`; color yellow `#FFD600`, orange `#FF6D00` when signal `<40`.
+4. **Otherwise** → **wired**: `LAN`, green `#00C853`. Quiet confirmation (no IP — display-only
+   was chosen; IP remains available via `ip a` or a future click action).
+
+`interval=10`. Optional future enhancement (noted, not built): a NetworkManager
+`dispatcher.d` hook that signals i3blocks on connectivity change for instant switch-over.
+
+Tooling confirmed present on hexane: `nmcli`, `iw`. Absent: `iwgetid`, `iwconfig` (do not use).
+
+## Key-leakage safeguards
+
+- Tokens read from `~/.claude/.credentials.json` and `~/.codex/auth.json` at runtime — never
+  embedded in scripts, never written into the repo.
+- Cache files in `~/.cache/i3blocks-aiusage/` — outside the repo.
+- Only percentages, SSID, and reset times ever reach the bar — no tokens, IPs (wired), or
+  account IDs.
+- `i3/.gitignore` already excludes the generated `config`; blocklets and this doc are tracked
+  as intended. The endpoint/header details recorded here are already public (GitHub
+  issues / source), not secrets.
+
+## Verification plan
+
+- `BLOCK_INSTANCE=claude i3/blocklets/ai_usage` → `CC 5h NN% 7d NN% …`; same for `codex`.
+- Failure path: temporarily rename a credential file → expect gray `CC ?`, exit 0.
+- Claude polling: confirm no more than one network call per 180 s under normal bar operation
+  (cache TTL enforces this).
+- Network: with wired up → `LAN` green; `nmcli dev disconnect <eth>` or unplug → wifi or
+  `no net`; confirm default-route detection never picks a docker/veth/bridge iface.
+- Reload: `i3-msg reload` (or restart i3blocks) and eyeball the three new segments.
+
+## Out of scope (YAGNI)
+
+- Click actions (display-only was chosen).
+- OAuth token refresh.
+- Cost / historical-usage graphs (ccusage covers cost if ever wanted).
+- Deleting the old GPL `iface`/`wifi` blocklets — left in place, just unreferenced.

--- a/i3/docs/2026-05-31-usage-and-network-blocklets-plan.md
+++ b/i3/docs/2026-05-31-usage-and-network-blocklets-plan.md
@@ -1,0 +1,773 @@
+# AI usage + adaptive network i3blocks — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three i3blocks segments on hexane — Claude Code usage, Codex usage (each 5h + weekly, verbose with reset countdowns), and one adaptive network indicator (quiet wired / loud wifi / urgent down).
+
+**Architecture:** Two new bash blocklets in the public repo `i3/blocklets/`. `ai_usage` is one script run twice (via `instance=claude|codex`) that hits each provider's official usage endpoint, caches the JSON in `~/.cache/`, and renders a colored segment; tokens are read from `$HOME` at runtime so no secret enters the repo. `network` keys off the default route. Both are made unit-testable with env-var seams (`AIUSAGE_CACHE_DIR`, `AIUSAGE_NO_FETCH`, `AIUSAGE_TEST_*`, `NET_TEST_*`) and a dependency-free fixture harness.
+
+**Tech Stack:** bash, `jq`, `curl`, GNU `date`/`stat`, `nmcli`/`iw`, i3blocks 1.5.
+
+**Spec:** `i3/docs/2026-05-31-usage-and-network-blocklets-design.md`
+
+**Conventions:** i3blocks script output = 3 lines (full_text, short_text, color `#RRGGBB`); `markup=none` is global so color comes from line 3. Scripts must always `exit 0` (except the deliberate `exit 33` urgent case) so a failure never breaks the bar. Colors: green `#00C853`, yellow `#FFD600`, orange `#FF6D00`, red `#FF1744`, gray `#888888`, cyan `#00B8D4`.
+
+> **Commit note:** Steps include `git -C ~/.dotfiles` commits. This is the user's public dotfiles repo; confirm with the user before the first commit and before any push (per their git workflow). Consider a branch (`git -C ~/.dotfiles checkout -b feat/i3-usage-network`) if they prefer.
+
+---
+
+### Task 1: Test harness + fixtures
+
+**Files:**
+- Create: `i3/blocklets/tests/assert.sh`
+- Create: `i3/blocklets/tests/run.sh`
+- Create: `i3/blocklets/tests/fixtures/claude_usage.json`
+- Create: `i3/blocklets/tests/fixtures/codex_wham.json`
+- Create: `i3/blocklets/tests/fixtures/codex_high.json`
+- Create: `i3/blocklets/tests/fixtures/codex_rollout_line.jsonl`
+
+- [ ] **Step 1: Create the assertion helper**
+
+`i3/blocklets/tests/assert.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Minimal dependency-free assertion helpers. Source this from test_*.sh.
+pass=0; fail=0
+assert_eq() { # $1 desc  $2 expected  $3 actual
+  if [ "$2" = "$3" ]; then pass=$((pass+1));
+  else fail=$((fail+1)); printf 'FAIL - %s\n  expected: %q\n  actual:   %q\n' "$1" "$2" "$3"; fi
+}
+assert_contains() { # $1 desc  $2 needle  $3 haystack
+  case "$3" in
+    *"$2"*) pass=$((pass+1));;
+    *) fail=$((fail+1)); printf 'FAIL - %s\n  needle: %q\n  in:     %q\n' "$1" "$2" "$3";;
+  esac
+}
+finish() { printf '%d passed, %d failed\n' "$pass" "$fail"; [ "$fail" -eq 0 ]; }
+```
+
+- [ ] **Step 2: Create the test runner**
+
+`i3/blocklets/tests/run.sh`:
+
+```bash
+#!/usr/bin/env bash
+cd "$(dirname "$0")" || exit 1
+rc=0
+for t in test_*.sh; do
+  [ -e "$t" ] || continue
+  echo "== $t =="
+  bash "$t" || rc=1
+done
+exit $rc
+```
+
+- [ ] **Step 3: Create fixtures** (synthetic — no real tokens/IDs; shapes match the verified live responses)
+
+`i3/blocklets/tests/fixtures/claude_usage.json`:
+
+```json
+{
+  "five_hour": { "utilization": 38.0, "resets_at": "2026-05-31T23:59:00+00:00" },
+  "seven_day": { "utilization": 60.0, "resets_at": "2099-01-01T00:00:00+00:00" },
+  "seven_day_opus": null,
+  "seven_day_sonnet": { "utilization": 5.0, "resets_at": "2099-01-01T00:00:00+00:00" }
+}
+```
+
+`i3/blocklets/tests/fixtures/codex_wham.json`:
+
+```json
+{
+  "plan_type": "pro",
+  "rate_limit": {
+    "allowed": true, "limit_reached": false,
+    "primary_window":   { "used_percent": 10, "limit_window_seconds": 18000,  "reset_after_seconds": 8672,   "reset_at": 1780295110 },
+    "secondary_window": { "used_percent": 8,  "limit_window_seconds": 604800, "reset_after_seconds": 559455, "reset_at": 1780845893 }
+  }
+}
+```
+
+`i3/blocklets/tests/fixtures/codex_high.json`:
+
+```json
+{
+  "plan_type": "pro",
+  "rate_limit": {
+    "primary_window":   { "used_percent": 92, "reset_after_seconds": 7200 },
+    "secondary_window": { "used_percent": 8,  "reset_after_seconds": 559455 }
+  }
+}
+```
+
+`i3/blocklets/tests/fixtures/codex_rollout_line.jsonl` (single line):
+
+```json
+{"type":"event_msg","payload":{"type":"token_count","info":{},"rate_limits":{"limit_id":"codex","plan_type":"pro","primary":{"used_percent":15.0,"window_minutes":300,"resets_at":1780277106},"secondary":{"used_percent":6.0,"window_minutes":10080,"resets_at":1780845892}}}}
+```
+
+- [ ] **Step 4: Make scripts executable and verify the runner works (empty)**
+
+Run:
+```bash
+chmod +x ~/.dotfiles/i3/blocklets/tests/run.sh
+bash ~/.dotfiles/i3/blocklets/tests/run.sh
+```
+Expected: exits 0, prints nothing (no `test_*.sh` yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C ~/.dotfiles add i3/blocklets/tests
+git -C ~/.dotfiles commit -m "test(i3): add blocklet test harness and usage fixtures"
+```
+
+---
+
+### Task 2: `ai_usage` — pure helpers + dispatch skeleton
+
+**Files:**
+- Create: `i3/blocklets/ai_usage`
+- Create: `i3/blocklets/tests/test_helpers.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+`i3/blocklets/tests/test_helpers.sh`:
+
+```bash
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+assert_eq "color 38 green"  "#00C853" "$(bash "$S" __color 38)"
+assert_eq "color 69 green"  "#00C853" "$(bash "$S" __color 69)"
+assert_eq "color 70 yellow" "#FFD600" "$(bash "$S" __color 70)"
+assert_eq "color 89 yellow" "#FFD600" "$(bash "$S" __color 89)"
+assert_eq "color 90 red"    "#FF1744" "$(bash "$S" __color 90)"
+assert_eq "reset minutes"   "7m"      "$(bash "$S" __reset 420)"
+assert_eq "reset hours"     "4h2m"    "$(bash "$S" __reset 14520)"
+assert_eq "reset days"      "3d4h"    "$(bash "$S" __reset 273600)"
+finish
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash ~/.dotfiles/i3/blocklets/tests/test_helpers.sh`
+Expected: FAIL (script `ai_usage` does not exist yet → `bash: .../ai_usage: No such file or directory`, assertions fail).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`i3/blocklets/ai_usage`:
+
+```bash
+#!/usr/bin/env bash
+# i3blocks: Claude Code / Codex usage (5h + weekly), verbose with reset countdowns.
+# Provider via $BLOCK_INSTANCE (claude|codex). Reads OAuth tokens from $HOME at
+# runtime — contains NO secrets. Safe to commit to a public repo.
+set -u
+
+pct_color() {
+  local p=${1:-0}
+  if   [ "$p" -ge 90 ]; then echo "#FF1744"
+  elif [ "$p" -ge 70 ]; then echo "#FFD600"
+  else                       echo "#00C853"
+  fi
+}
+
+fmt_reset() {
+  local s=${1:-0} d h m
+  d=$(( s / 86400 )); h=$(( (s % 86400) / 3600 )); m=$(( (s % 3600) / 60 ))
+  if   [ "$d" -gt 0 ]; then echo "${d}d${h}h"
+  elif [ "$h" -gt 0 ]; then echo "${h}h${m}m"
+  else                      echo "${m}m"
+  fi
+}
+
+render_claude() { return 1; }   # implemented in Task 3
+render_codex()  { return 1; }   # implemented in Task 4
+main()          { :; }          # implemented in Task 5
+
+# ---- dispatch ----
+case "${1:-}" in
+  __color)  pct_color "${2:-0}"; exit 0 ;;
+  __reset)  fmt_reset "${2:-0}"; exit 0 ;;
+  __render) "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
+  *)        main ;;
+esac
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+chmod +x ~/.dotfiles/i3/blocklets/ai_usage
+bash ~/.dotfiles/i3/blocklets/tests/test_helpers.sh
+```
+Expected: `8 passed, 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C ~/.dotfiles add i3/blocklets/ai_usage i3/blocklets/tests/test_helpers.sh
+git -C ~/.dotfiles commit -m "feat(i3): ai_usage helpers (pct color, reset formatting)"
+```
+
+---
+
+### Task 3: `ai_usage` — Claude parse + render
+
+**Files:**
+- Modify: `i3/blocklets/ai_usage` (replace the `render_claude` stub)
+- Create: `i3/blocklets/tests/test_claude.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+`i3/blocklets/tests/test_claude.sh`:
+
+```bash
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+out=$(BLOCK_INSTANCE=claude bash "$S" __render < "$DIR/fixtures/claude_usage.json")
+full=$(sed -n 1p <<<"$out"); short=$(sed -n 2p <<<"$out"); color=$(sed -n 3p <<<"$out")
+assert_contains "claude 5h no reset (<50)" "5h 38% 7d 60% (" "$full"
+assert_contains "claude 7d pct"            "7d 60%"          "$full"
+assert_eq       "claude short"             "CC 38/60"        "$short"
+assert_eq       "claude color worst=60"    "#00C853"         "$color"
+finish
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash ~/.dotfiles/i3/blocklets/tests/test_claude.sh`
+Expected: FAIL (stub returns 1 → no output; assertions fail).
+
+- [ ] **Step 3: Write minimal implementation** — replace the `render_claude` stub line
+
+In `i3/blocklets/ai_usage`, replace:
+```bash
+render_claude() { return 1; }   # implemented in Task 3
+```
+with:
+```bash
+render_claude() {
+  local json=$1 now five sev seg5 seg7 worst color r ts
+  now=$(date +%s)
+  five=$(jq -r '.five_hour.utilization // empty' <<<"$json"); five=${five%.*}
+  sev=$(jq -r '.seven_day.utilization // empty' <<<"$json"); sev=${sev%.*}
+  { [ -z "$five" ] || [ -z "$sev" ]; } && return 1
+  seg5="5h ${five}%"; seg7="7d ${sev}%"
+  if [ "$five" -ge 50 ]; then
+    ts=$(jq -r '.five_hour.resets_at // empty' <<<"$json")
+    [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg5="$seg5 ($(fmt_reset "$r"))"
+  fi
+  if [ "$sev" -ge 50 ]; then
+    ts=$(jq -r '.seven_day.resets_at // empty' <<<"$json")
+    [ -n "$ts" ] && r=$(( $(date -d "$ts" +%s 2>/dev/null || echo "$now") - now )) && [ "$r" -gt 0 ] && seg7="$seg7 ($(fmt_reset "$r"))"
+  fi
+  worst=$five; [ "$sev" -gt "$worst" ] && worst=$sev
+  color=$(pct_color "$worst")
+  printf '%s\n%s\n%s\n' "CC $seg5 $seg7" "CC ${five}/${sev}" "$color"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash ~/.dotfiles/i3/blocklets/tests/test_claude.sh`
+Expected: `4 passed, 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C ~/.dotfiles add i3/blocklets/ai_usage i3/blocklets/tests/test_claude.sh
+git -C ~/.dotfiles commit -m "feat(i3): ai_usage Claude usage parse + render"
+```
+
+---
+
+### Task 4: `ai_usage` — Codex parse + render
+
+**Files:**
+- Modify: `i3/blocklets/ai_usage` (replace the `render_codex` stub)
+- Create: `i3/blocklets/tests/test_codex.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+`i3/blocklets/tests/test_codex.sh`:
+
+```bash
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+
+# normal: 10% / 8% -> green, no resets (<50)
+out=$(BLOCK_INSTANCE=codex bash "$S" __render < "$DIR/fixtures/codex_wham.json")
+assert_eq "codex full"  "CX 5h 10% wk 8%" "$(sed -n 1p <<<"$out")"
+assert_eq "codex short" "CX 10/8"         "$(sed -n 2p <<<"$out")"
+assert_eq "codex color" "#00C853"         "$(sed -n 3p <<<"$out")"
+
+# high: 92% with 2h reset -> red, reset shown (reset_after_seconds is deterministic)
+out=$(BLOCK_INSTANCE=codex bash "$S" __render < "$DIR/fixtures/codex_high.json")
+assert_eq "codex high full"  "CX 5h 92% (2h0m) wk 8%" "$(sed -n 1p <<<"$out")"
+assert_eq "codex high color" "#FF1744"                "$(sed -n 3p <<<"$out")"
+finish
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash ~/.dotfiles/i3/blocklets/tests/test_codex.sh`
+Expected: FAIL (stub returns 1 → no output).
+
+- [ ] **Step 3: Write minimal implementation** — replace the `render_codex` stub line
+
+In `i3/blocklets/ai_usage`, replace:
+```bash
+render_codex()  { return 1; }   # implemented in Task 4
+```
+with:
+```bash
+render_codex() {
+  local json=$1 five wk seg5 segw worst color r
+  five=$(jq -r '.rate_limit.primary_window.used_percent // empty'   <<<"$json"); five=${five%.*}
+  wk=$(jq -r   '.rate_limit.secondary_window.used_percent // empty' <<<"$json"); wk=${wk%.*}
+  { [ -z "$five" ] || [ -z "$wk" ]; } && return 1
+  seg5="5h ${five}%"; segw="wk ${wk}%"
+  if [ "$five" -ge 50 ]; then
+    r=$(jq -r '.rate_limit.primary_window.reset_after_seconds // empty' <<<"$json")
+    [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null && seg5="$seg5 ($(fmt_reset "$r"))"
+  fi
+  if [ "$wk" -ge 50 ]; then
+    r=$(jq -r '.rate_limit.secondary_window.reset_after_seconds // empty' <<<"$json")
+    [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null && segw="$segw ($(fmt_reset "$r"))"
+  fi
+  worst=$five; [ "$wk" -gt "$worst" ] && worst=$wk
+  color=$(pct_color "$worst")
+  printf '%s\n%s\n%s\n' "CX $seg5 $segw" "CX ${five}/${wk}" "$color"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash ~/.dotfiles/i3/blocklets/tests/test_codex.sh`
+Expected: `5 passed, 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C ~/.dotfiles add i3/blocklets/ai_usage i3/blocklets/tests/test_codex.sh
+git -C ~/.dotfiles commit -m "feat(i3): ai_usage Codex usage parse + render"
+```
+
+---
+
+### Task 5: `ai_usage` — fetch, cache, fallback, main
+
+**Files:**
+- Modify: `i3/blocklets/ai_usage` (replace the `main` stub; add fetch/validate/cache/rollout functions; extend dispatch)
+- Create: `i3/blocklets/tests/test_ai_fallback.sh`
+- Create: `i3/blocklets/tests/test_codex_rollout.sh`
+
+- [ ] **Step 1: Write the failing tests**
+
+`i3/blocklets/tests/test_ai_fallback.sh`:
+
+```bash
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+TMP=$(mktemp -d); cp "$DIR/fixtures/claude_usage.json" "$TMP/claude.json"
+
+# fresh cache -> live color (green), real text
+out=$(AIUSAGE_CACHE_DIR="$TMP" BLOCK_INSTANCE=claude bash "$S")
+assert_eq       "fresh cache live color" "#00C853"   "$(sed -n 3p <<<"$out")"
+assert_contains "fresh cache text"       "CC 5h 38%" "$(sed -n 1p <<<"$out")"
+
+# stale cache + no fetch -> dim (gray) but text preserved
+touch -d '1 hour ago' "$TMP/claude.json"
+out=$(AIUSAGE_CACHE_DIR="$TMP" AIUSAGE_NO_FETCH=1 BLOCK_INSTANCE=claude bash "$S")
+assert_eq       "stale dim color"  "#888888"   "$(sed -n 3p <<<"$out")"
+assert_contains "stale text kept"  "CC 5h 38%" "$(sed -n 1p <<<"$out")"
+
+# no cache + no fetch -> "CC ?"
+TMP2=$(mktemp -d)
+out=$(AIUSAGE_CACHE_DIR="$TMP2" AIUSAGE_NO_FETCH=1 BLOCK_INSTANCE=claude bash "$S")
+assert_eq "no-data full"  "CC ?"    "$(sed -n 1p <<<"$out")"
+assert_eq "no-data color" "#888888" "$(sed -n 3p <<<"$out")"
+
+rm -rf "$TMP" "$TMP2"
+finish
+```
+
+`i3/blocklets/tests/test_codex_rollout.sh`:
+
+```bash
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../ai_usage"
+mapped=$(bash "$S" __maprollout < "$DIR/fixtures/codex_rollout_line.jsonl")
+out=$(BLOCK_INSTANCE=codex bash "$S" __render <<<"$mapped")
+assert_contains "rollout 5h" "5h 15%" "$(sed -n 1p <<<"$out")"
+assert_contains "rollout wk" "wk 6%"  "$(sed -n 1p <<<"$out")"
+finish
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+bash ~/.dotfiles/i3/blocklets/tests/test_ai_fallback.sh
+bash ~/.dotfiles/i3/blocklets/tests/test_codex_rollout.sh
+```
+Expected: both FAIL (`main` is a stub → no output; `__maprollout` not handled).
+
+- [ ] **Step 3a: Add fetch/validate/cache/rollout functions** — insert immediately above the `# ---- dispatch ----` line
+
+In `i3/blocklets/ai_usage`, insert before `# ---- dispatch ----`:
+
+```bash
+CACHE_DIR="${AIUSAGE_CACHE_DIR:-$HOME/.cache/i3blocks-aiusage}"
+
+fetch_claude() {
+  [ -n "${AIUSAGE_NO_FETCH:-}" ] && return 1
+  local cred="$HOME/.claude/.credentials.json" token ver
+  [ -f "$cred" ] || return 1
+  token=$(jq -r '.claudeAiOauth.accessToken // empty' "$cred"); [ -z "$token" ] && return 1
+  ver=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1); ver=${ver:-2.1.159}
+  curl -sS --max-time 6 \
+    -H "Authorization: Bearer $token" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "User-Agent: claude-code/$ver" \
+    "https://api.anthropic.com/api/oauth/usage" 2>/dev/null
+}
+validate_claude() { jq -e '.five_hour.utilization' >/dev/null 2>&1 <<<"${1:-}"; }
+
+fetch_codex() {
+  [ -n "${AIUSAGE_NO_FETCH:-}" ] && return 1
+  local auth="$HOME/.codex/auth.json" token acct
+  [ -f "$auth" ] || return 1
+  token=$(jq -r '.tokens.access_token // empty' "$auth"); [ -z "$token" ] && return 1
+  acct=$(jq -r '.tokens.account_id // empty' "$auth")
+  curl -sS --max-time 6 \
+    -H "Authorization: Bearer $token" \
+    -H "ChatGPT-Account-Id: $acct" \
+    -H "User-Agent: codex-cli" \
+    "https://chatgpt.com/backend-api/wham/usage" 2>/dev/null
+}
+validate_codex() { jq -e '.rate_limit.primary_window.used_percent' >/dev/null 2>&1 <<<"${1:-}"; }
+
+# stdin: one rollout JSONL line -> stdout: wham-shaped JSON (or exit 1)
+map_rollout_line() {
+  jq -e -c '
+    .payload.rate_limits as $r
+    | select($r != null and $r.primary != null)
+    | def after($w): (if $w.resets_at then ($w.resets_at - now)
+                      elif $w.resets_in_seconds then $w.resets_in_seconds
+                      else 0 end | floor);
+      { rate_limit: {
+          primary_window:   { used_percent: $r.primary.used_percent,   reset_after_seconds: after($r.primary) },
+          secondary_window: { used_percent: $r.secondary.used_percent, reset_after_seconds: after($r.secondary) } } }
+  ' 2>/dev/null
+}
+
+codex_rollout_json() {
+  local f line
+  f=$(ls -t "$HOME"/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -1); [ -n "$f" ] || return 1
+  line=$(grep '"rate_limits"' "$f" 2>/dev/null | tail -1); [ -n "$line" ] || return 1
+  printf '%s' "$line" | map_rollout_line
+}
+
+label() { case "${BLOCK_INSTANCE:-claude}" in codex) echo "CX";; *) echo "CC";; esac; }
+
+# re-render the given JSON but force the color line to gray (stale/fallback marker)
+emit_dim() {
+  local out; out=$("render_${BLOCK_INSTANCE:-claude}" "$1") || return 1
+  printf '%s\n%s\n#888888\n' "$(sed -n 1p <<<"$out")" "$(sed -n 2p <<<"$out")"
+}
+
+```
+
+- [ ] **Step 3b: Replace the `main` stub**
+
+In `i3/blocklets/ai_usage`, replace:
+```bash
+main()          { :; }          # implemented in Task 5
+```
+with:
+```bash
+main() {
+  local provider="${BLOCK_INSTANCE:-claude}" ttl cache json
+  case "$provider" in codex) ttl=120;; *) ttl=180;; esac
+  mkdir -p "$CACHE_DIR"; cache="$CACHE_DIR/$provider.json"
+
+  # 1) fresh cache -> live color
+  if [ -f "$cache" ] && [ $(( $(date +%s) - $(stat -c %Y "$cache") )) -lt "$ttl" ]; then
+    "render_$provider" "$(cat "$cache")" && return 0
+  fi
+  # 2) fetch live; cache only on valid response
+  json=$("fetch_$provider")
+  if "validate_$provider" "$json"; then
+    printf '%s' "$json" > "$cache"
+    "render_$provider" "$json" && return 0
+  fi
+  # 3) fallbacks, rendered gray
+  if [ "$provider" = "codex" ] && json=$(codex_rollout_json) && [ -n "$json" ]; then
+    emit_dim "$json" && return 0
+  fi
+  if [ -f "$cache" ]; then emit_dim "$(cat "$cache")" && return 0; fi
+  # 4) nothing available
+  local l; l=$(label); printf '%s ?\n%s ?\n#888888\n' "$l" "$l"
+}
+```
+
+- [ ] **Step 3c: Extend the dispatch** to expose `map_rollout_line`
+
+In `i3/blocklets/ai_usage`, replace:
+```bash
+  __render) "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
+```
+with:
+```bash
+  __render)     "render_${BLOCK_INSTANCE:-claude}" "$(cat)"; exit $? ;;
+  __maprollout) map_rollout_line; exit $? ;;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+bash ~/.dotfiles/i3/blocklets/tests/run.sh
+```
+Expected: every `test_*.sh` reports `0 failed`; runner exits 0.
+
+- [ ] **Step 5: Live smoke test** (makes real network calls; both endpoints were verified working on hexane)
+
+Run:
+```bash
+BLOCK_INSTANCE=claude ~/.dotfiles/i3/blocklets/ai_usage
+echo "---"
+BLOCK_INSTANCE=codex  ~/.dotfiles/i3/blocklets/ai_usage
+```
+Expected: line 1 like `CC 5h NN% 7d NN%` (with `(…)` on any window ≥50%) and a `#RRGGBB` on line 3; same for `CX`. If a token is missing/expired you'll see `CC ?`/`CX ?` in gray — that's the correct failure behavior, not a bug.
+
+- [ ] **Step 6: Confirm cache was written and polling is bounded**
+
+Run:
+```bash
+ls -l ~/.cache/i3blocks-aiusage/
+```
+Expected: `claude.json` and/or `codex.json` present. Re-running within the TTL serves from cache (no network call), keeping Claude under its 180 s polling floor.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C ~/.dotfiles add i3/blocklets/ai_usage i3/blocklets/tests/test_ai_fallback.sh i3/blocklets/tests/test_codex_rollout.sh
+git -C ~/.dotfiles commit -m "feat(i3): ai_usage fetch, cache, and gray-fallback orchestration"
+```
+
+---
+
+### Task 6: `network` blocklet
+
+**Files:**
+- Create: `i3/blocklets/network`
+- Create: `i3/blocklets/tests/test_network.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+`i3/blocklets/tests/test_network.sh`:
+
+```bash
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../network"
+
+# no default route -> urgent "no net"
+out=$(NET_TEST_IF= bash "$S"); ec=$?
+assert_eq "down full"  "no net"  "$(sed -n 1p <<<"$out")"
+assert_eq "down color" "#FF1744" "$(sed -n 3p <<<"$out")"
+assert_eq "down exit"  "33"      "$ec"
+
+# vpn iface
+out=$(NET_TEST_IF=tun0 bash "$S")
+assert_eq "vpn full"  "VPN"     "$(sed -n 1p <<<"$out")"
+assert_eq "vpn color" "#00B8D4" "$(sed -n 3p <<<"$out")"
+
+# wifi strong signal
+out=$(NET_TEST_IF=wlo1 NET_TEST_WIRELESS=1 NET_TEST_SSID="MyAP-5G" NET_TEST_SIGNAL=72 bash "$S")
+assert_eq "wifi full"  "MyAP-5G 72%" "$(sed -n 1p <<<"$out")"
+assert_eq "wifi color" "#FFD600"     "$(sed -n 3p <<<"$out")"
+
+# wifi weak signal -> orange
+out=$(NET_TEST_IF=wlo1 NET_TEST_WIRELESS=1 NET_TEST_SSID="Far" NET_TEST_SIGNAL=22 bash "$S")
+assert_eq "wifi weak color" "#FF6D00" "$(sed -n 3p <<<"$out")"
+
+# wired -> quiet LAN
+out=$(NET_TEST_IF=enp8s0f0 NET_TEST_WIRELESS=0 bash "$S")
+assert_eq "wired full"  "LAN"     "$(sed -n 1p <<<"$out")"
+assert_eq "wired color" "#00C853" "$(sed -n 3p <<<"$out")"
+finish
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash ~/.dotfiles/i3/blocklets/tests/test_network.sh`
+Expected: FAIL (`network` does not exist).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`i3/blocklets/network`:
+
+```bash
+#!/usr/bin/env bash
+# i3blocks: adaptive network indicator. Keys off the default route so it ignores
+# docker/veth/bridge interfaces. Quiet on wired, loud (SSID+signal) on wifi,
+# urgent when down. Test seams: NET_TEST_IF / NET_TEST_WIRELESS / NET_TEST_SSID /
+# NET_TEST_SIGNAL (use the ${VAR-...} form so an empty value is honored).
+set -u
+
+get_iface()   { echo "${NET_TEST_IF-$(ip route show default 2>/dev/null | awk '/^default/{print $5; exit}')}"; }
+is_wireless() {
+  if [ -n "${NET_TEST_WIRELESS+x}" ]; then [ "$NET_TEST_WIRELESS" = 1 ]
+  else [ -d "/sys/class/net/$1/wireless" ]; fi
+}
+get_ssid()   { echo "${NET_TEST_SSID-$(nmcli -t -f active,ssid   dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}')}"; }
+get_signal() { echo "${NET_TEST_SIGNAL-$(nmcli -t -f active,signal dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}')}"; }
+
+IF=$(get_iface)
+
+if [ -z "$IF" ]; then
+  printf 'no net\nno net\n#FF1744\n'; exit 33   # i3blocks: exit 33 marks the block urgent
+fi
+
+case "$IF" in
+  tun*|wg*|tap*) printf 'VPN\nVPN\n#00B8D4\n'; exit 0 ;;
+esac
+
+if is_wireless "$IF"; then
+  ssid=$(get_ssid); sig=$(get_signal)
+  [ -z "$ssid" ] && ssid="wifi"
+  color="#FFD600"; [ -n "$sig" ] && [ "$sig" -lt 40 ] 2>/dev/null && color="#FF6D00"
+  if [ -n "$sig" ]; then text="$ssid ${sig}%"; else text="$ssid"; fi
+  printf '%s\n%s\n%s\n' "$text" "$text" "$color"; exit 0
+fi
+
+printf 'LAN\nLAN\n#00C853\n'; exit 0
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+chmod +x ~/.dotfiles/i3/blocklets/network
+bash ~/.dotfiles/i3/blocklets/tests/test_network.sh
+```
+Expected: `9 passed, 0 failed`.
+
+- [ ] **Step 5: Live smoke test** (real state — currently wired on hexane)
+
+Run: `~/.dotfiles/i3/blocklets/network`
+Expected: `LAN` / `LAN` / `#00C853` (you are on wired `enp8s0f0`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C ~/.dotfiles add i3/blocklets/network i3/blocklets/tests/test_network.sh
+git -C ~/.dotfiles commit -m "feat(i3): adaptive network blocklet (wired/wifi/vpn/down)"
+```
+
+---
+
+### Task 7: Wire blocks into the bar + verify
+
+**Files:**
+- Modify: `i3/i3blocks.conf` (insert three sections before `[time]`)
+
+- [ ] **Step 1: Add the three blocks** — edit `~/.dotfiles/i3/i3blocks.conf`
+
+Replace this region:
+```ini
+[volume]
+label=♪
+instance=Master
+signal=10
+
+
+# Date Time
+[time]
+```
+with:
+```ini
+[volume]
+label=♪
+instance=Master
+signal=10
+
+
+# Network: quiet wired, loud wifi, urgent down
+[network]
+interval=10
+separator=true
+
+# Claude Code usage (5h + 7d)
+[claude_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=claude
+interval=300
+
+# Codex usage (5h + weekly)
+[codex_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=codex
+interval=300
+
+
+# Date Time
+[time]
+```
+
+- [ ] **Step 2: Sanity-check each block the way i3blocks will invoke it**
+
+Run (i3blocks sets `$SCRIPT_DIR` and `$BLOCK_INSTANCE`; simulate it):
+```bash
+SCRIPT_DIR=~/.dotfiles/i3/blocklets BLOCK_INSTANCE= bash ~/.dotfiles/i3/blocklets/network
+SCRIPT_DIR=~/.dotfiles/i3/blocklets BLOCK_INSTANCE=claude bash ~/.dotfiles/i3/blocklets/ai_usage
+SCRIPT_DIR=~/.dotfiles/i3/blocklets BLOCK_INSTANCE=codex  bash ~/.dotfiles/i3/blocklets/ai_usage
+```
+Expected: three valid 3-line outputs (`LAN…`, `CC…`, `CX…`).
+
+- [ ] **Step 3: Reload i3 so the bar re-reads i3blocks.conf**
+
+`~/.i3blocks.conf` is a symlink to `i3/i3blocks.conf`, so the edit is already deployed; i3blocks only re-reads its config on (re)start.
+
+Run: `i3-msg restart`
+Expected: `[{"success":true}]`. i3 re-execs in place (windows/workspaces preserved) and the bar respawns i3blocks with the new config.
+
+- [ ] **Step 4: Visually verify the bar**
+
+Look at the top bar. Expected, left of the clock: `LAN` (green), then `CC 5h NN% 7d NN%`, then `CX 5h NN% wk NN%`. Confirm colors look right and nothing shows a raw error or stays blank.
+
+- [ ] **Step 5: Full test suite green**
+
+Run: `bash ~/.dotfiles/i3/blocklets/tests/run.sh && echo ALL_GREEN`
+Expected: ends with `ALL_GREEN`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C ~/.dotfiles add i3/i3blocks.conf
+git -C ~/.dotfiles commit -m "feat(i3): wire network + Claude/Codex usage blocks into bar"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Claude endpoint/headers/fields + verbose render + reset ≥50% → Task 3. ✓
+- Codex endpoint/headers/fields + verbose render + reset ≥50% → Task 4. ✓
+- Cache (TTL: Claude 180s / Codex 120s), read-only token, gray failure, never-refresh, always exit 0 → Task 5. ✓
+- Codex rollout fallback (null-safe, resets_at/resets_in_seconds drift) → Task 5 (`map_rollout_line`, `codex_rollout_json`). ✓
+- Network: default-route keying, no-route urgent, VPN, wifi SSID+signal (orange <40), quiet wired → Task 6. ✓
+- Two separate blocks via `instance` → Tasks 2/7. ✓
+- Wiring before `[time]`, symlink note, reload → Task 7. ✓
+- Key-leakage: tokens read from `$HOME`, cache in `~/.cache`, only %/SSID/resets on bar, fixtures synthetic → Tasks 1/5/6. ✓
+- Verification plan (manual invocation, failure path, polling bound, network states) → Tasks 5/6/7. ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows complete code; every run step shows the command and expected output. The `exit 33` urgent behavior is annotated and visually verified in Task 7 (red color is the baseline signal regardless). ✓
+
+**Type/name consistency:** `pct_color`, `fmt_reset`, `render_claude`, `render_codex`, `fetch_claude/codex`, `validate_claude/codex`, `map_rollout_line`, `codex_rollout_json`, `label`, `emit_dim`, `main`, and `CACHE_DIR` are defined once and referenced consistently. Dispatch tokens `__color/__reset/__render/__maprollout` match between `ai_usage` and the tests. Test seam names (`AIUSAGE_CACHE_DIR`, `AIUSAGE_NO_FETCH`, `NET_TEST_IF/WIRELESS/SSID/SIGNAL`) match between scripts and tests. ✓

--- a/i3/docs/2026-05-31-usage-and-network-blocklets-plan.md
+++ b/i3/docs/2026-05-31-usage-and-network-blocklets-plan.md
@@ -707,13 +707,13 @@ separator=true
 [claude_usage]
 command=$SCRIPT_DIR/ai_usage
 instance=claude
-interval=300
+interval=1200
 
 # Codex usage (5h + weekly)
 [codex_usage]
 command=$SCRIPT_DIR/ai_usage
 instance=codex
-interval=300
+interval=1200
 
 
 # Date Time

--- a/i3/i3blocks.conf
+++ b/i3/i3blocks.conf
@@ -75,13 +75,13 @@ separator=true
 [claude_usage]
 command=$SCRIPT_DIR/ai_usage
 instance=claude
-interval=300
+interval=1200
 
 # Codex usage (5h + weekly)
 [codex_usage]
 command=$SCRIPT_DIR/ai_usage
 instance=codex
-interval=300
+interval=1200
 
 
 # Date Time

--- a/i3/i3blocks.conf
+++ b/i3/i3blocks.conf
@@ -66,6 +66,24 @@ instance=Master
 signal=10
 
 
+# Network: quiet wired, loud wifi, urgent down
+[network]
+interval=10
+separator=true
+
+# Claude Code usage (5h + 7d)
+[claude_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=claude
+interval=300
+
+# Codex usage (5h + weekly)
+[codex_usage]
+command=$SCRIPT_DIR/ai_usage
+instance=codex
+interval=300
+
+
 # Date Time
 [time]
 # https://fontawesome.com/icons/calendar-alt?style=regular


### PR DESCRIPTION
## Summary
Two new i3blocks blocklets for the hexane bar, plus a dependency-free test harness and docs. **No secrets enter the repo** — OAuth tokens are read from `$HOME` at runtime; the cache lives in `~/.cache/`.

### `ai_usage` — Claude Code + Codex usage
- Two segments (`instance=claude|codex`) showing the rolling **5-hour** and **weekly** windows, verbose with reset countdowns:
  `CC 5h 10% 7d 67% ⚠️13 (3d4h)` · `CX 5h 3% wk 11% ✅`
- Hits each provider's official usage endpoint (`api.anthropic.com/api/oauth/usage`, `chatgpt.com/backend-api/wham/usage`), caches in `~/.cache/i3blocks-aiusage/` (≥180s polling floor for Claude), colors by worst-window utilization (green `<70` / yellow `70–89` / red `≥90`), and degrades to a gray stale value (or `CC ?`) on any failure. Read-only — **never refreshes** the OAuth token. Polls every **20 min**.
- **Weekly pace indicator** (both providers): compares weekly usage to an even 1/7-per-day pace toward 100% — `⚠️N` = N points ahead (ease off), `🦥N` = N behind (speed up), `✅` = on pace (±5). The 5-hour window gets no pace token (it's a rolling limit, not a consume-to-100% goal).

### `network` — adaptive indicator
- Keys off the **default route** (ignores docker/veth/bridge ifaces): quiet `LAN` on wired, loud `SSID NN%` on Wi-Fi (orange if weak), `VPN` for tunnels, urgent red `no net` when down.

### Tests + docs
- Dependency-free bash fixture harness with env-var seams and hidden dispatch verbs — **53 assertions, hermetic** (no live network/tokens).
- Design spec + implementation plan in `i3/docs/`; a README in `i3/blocklets/`.

### Secret safety (public repo)
Tokens read at runtime from `~/.claude/.credentials.json` and `~/.codex/auth.json`; cache in `~/.cache/`; fixtures synthetic. Only percentages / SSID / reset times ever reach the bar.

## Test Plan
- [ ] `bash i3/blocklets/tests/run.sh` → `53 passed, 0 failed`
- [ ] `BLOCK_INSTANCE=claude i3/blocklets/ai_usage` and `…=codex …` render correctly
- [ ] `i3/blocklets/network` → `LAN` on wired; disconnect → Wi-Fi / `no net`
- [ ] `i3-msg restart` → all three segments render on the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)