### PR TITLE
i3blocks: world clock (Zagreb / Prague / Kyiv)

### DIFF
--- a/i3/blocklets/README.md
+++ b/i3/blocklets/README.md
@@ -7,8 +7,8 @@ Each script prints the i3blocks 3-line protocol — `full_text`, `short_text`, `
 (`#RRGGBB`); `markup=none` is set globally.
 
 Most files here are stock [i3blocks-contrib](https://github.com/vivien/i3blocks-contrib)
-scripts (`battery`, `cpu_usage`, `disk`, `memory`, `volume`, `iface`, `wifi`, …). The two
-documented below — `ai_usage` and `network` — are custom.
+scripts (`battery`, `cpu_usage`, `disk`, `memory`, `volume`, `iface`, `wifi`, …). The three
+documented below — `ai_usage`, `network`, and `worldclock` — are custom.
 
 > **Reload:** i3blocks only re-reads its config when the bar (re)starts. After editing
 > `i3blocks.conf`, run **`i3-msg restart`** (in-place; windows/workspaces preserved). A
@@ -92,14 +92,33 @@ the host's many docker / veth / bridge interfaces:
 
 SSID and signal come from `nmcli` (falling back to `iw`).
 
+## `worldclock` — Zagreb / Prague / Kyiv
+
+Single block (`[worldclock]`, `interval=30`). Live time in three cities, collapsing those
+that currently share a clock:
+
+```
+ZAG·PRG 21:03  KYV 22:03
+```
+
+Zagreb and Prague are both Central European Time and always show the same clock; Kyiv is one
+hour ahead (Eastern European Time). The grouping is computed from the *actual* rendered
+times, so it's DST-aware and self-correcting — if two cities' clocks ever diverged they'd
+split into separate labels automatically. `full_text` shows the labelled groups; `short_text`
+drops the labels (`21:03 22:03`).
+
+Pure `date`/`TZ` — no network, no secrets, always exits 0. The `WORLDCLOCK_NOW=<epoch>` seam
+pins "now" so the summer/winter tests assert exact strings across a DST boundary.
+
 ## Tests
 
-Dependency-free bash harness (no `bats`/`shellcheck` required). Both custom scripts expose
-env-var seams (`AIUSAGE_CACHE_DIR`, `AIUSAGE_NO_FETCH`, `AIUSAGE_ROLLOUT_FILE`,
-`NET_TEST_IF`/`NET_TEST_WIRELESS`/`NET_TEST_SSID`/`NET_TEST_SIGNAL`) and hidden dispatch
-verbs (`__color`, `__reset`, `__pace`, `__render`, `__maprollout`) so every branch —
-thresholds, pace math, parsing, caching, fallbacks, all network states — is testable
-offline against synthetic fixtures (no live network or tokens needed).
+Dependency-free bash harness (no `bats`/`shellcheck` required). All three custom scripts
+expose env-var seams (`AIUSAGE_CACHE_DIR`, `AIUSAGE_NO_FETCH`, `AIUSAGE_ROLLOUT_FILE`,
+`NET_TEST_IF`/`NET_TEST_WIRELESS`/`NET_TEST_SSID`/`NET_TEST_SIGNAL`, `WORLDCLOCK_NOW`) and
+hidden dispatch verbs (`__color`, `__reset`, `__pace`, `__render`, `__maprollout`) so every
+branch — thresholds, pace math, parsing, caching, fallbacks, all network states, world-clock
+DST collapse — is testable offline against synthetic fixtures (no live network or tokens
+needed).
 
 ```sh
 bash tests/run.sh        # runs every tests/test_*.sh

--- a/i3/blocklets/tests/test_worldclock.sh
+++ b/i3/blocklets/tests/test_worldclock.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../worldclock"
+
+# Fixed UTC instants -> deterministic regardless of host TZ.
+# Summer: 2026-07-01 12:00 UTC -> Zagreb/Prague +2 (14:00), Kyiv +3 (15:00)
+summer=$(date -u -d '2026-07-01 12:00:00' +%s)
+out=$(WORLDCLOCK_NOW=$summer bash "$S" __render)
+assert_eq "summer full"  "ZAG·PRG 14:00  KYV 15:00" "$(sed -n 1p <<<"$out")"
+assert_eq "summer short" "14:00 15:00"              "$(sed -n 2p <<<"$out")"
+
+# Winter: 2026-01-15 12:00 UTC -> Zagreb/Prague +1 (13:00), Kyiv +2 (14:00).
+# Same UTC instant, different display => DST-aware; ZAG·PRG stays collapsed, KYV +1h.
+winter=$(date -u -d '2026-01-15 12:00:00' +%s)
+wout=$(WORLDCLOCK_NOW=$winter bash "$S" __render)
+assert_eq "winter full"  "ZAG·PRG 13:00  KYV 14:00" "$(sed -n 1p <<<"$wout")"
+assert_eq "winter short" "13:00 14:00"              "$(sed -n 2p <<<"$wout")"
+
+# Collapse invariant: ZAG·PRG share one group, exactly two time tokens.
+assert_contains "summer collapses ZAG·PRG" "ZAG·PRG" "$(sed -n 1p <<<"$out")"
+ntok=$(sed -n 2p <<<"$out" | tr ' ' '\n' | grep -c ':')
+assert_eq "summer has two time tokens" "2" "$ntok"
+finish

--- a/i3/blocklets/worldclock
+++ b/i3/blocklets/worldclock
@@ -9,7 +9,7 @@ set -u
 CITIES=(
   "ZAG|Europe/Zagreb"
   "PRG|Europe/Prague"
-  "KYV|Europe/Kiev"
+  "KYV|Europe/Kyiv"
 )
 
 time_in() {  # <tz> -> HH:MM at the current (or pinned) instant

--- a/i3/blocklets/worldclock
+++ b/i3/blocklets/worldclock
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# worldclock — i3blocks segment: live time in Zagreb, Prague, Kyiv.
+# Zagreb & Prague share CET (always equal); Kyiv is EET (+1h). Cities whose
+# current HH:MM match are collapsed under a joined label. Pure date/TZ — no
+# network, no secrets, always exits 0. Test seam: WORLDCLOCK_NOW=<epoch> pins now.
+set -u
+
+# label|tz, ordered west-to-east by offset
+CITIES=(
+  "ZAG|Europe/Zagreb"
+  "PRG|Europe/Prague"
+  "KYV|Europe/Kiev"
+)
+
+time_in() {  # <tz> -> HH:MM at the current (or pinned) instant
+  local tz=$1
+  if [ -n "${WORLDCLOCK_NOW:-}" ]; then
+    TZ="$tz" date -d "@$WORLDCLOCK_NOW" +%H:%M
+  else
+    TZ="$tz" date +%H:%M
+  fi
+}
+
+render() {
+  local entry lab tz i gi found
+  local labels=() times=()
+  for entry in "${CITIES[@]}"; do
+    lab=${entry%%|*}; tz=${entry#*|}
+    labels+=("$lab"); times+=("$(time_in "$tz")")
+  done
+  # group cities by equal time, preserving first-appearance order
+  local group_times=() group_labels=()
+  for i in "${!times[@]}"; do
+    found=-1
+    for gi in "${!group_times[@]}"; do
+      [ "${group_times[$gi]}" = "${times[$i]}" ] && { found=$gi; break; }
+    done
+    if [ "$found" -ge 0 ]; then
+      group_labels[$found]="${group_labels[$found]}·${labels[$i]}"
+    else
+      group_times+=("${times[$i]}"); group_labels+=("${labels[$i]}")
+    fi
+  done
+  local full="" short=""
+  for gi in "${!group_times[@]}"; do
+    [ -n "$full" ]  && full+="  "
+    [ -n "$short" ] && short+=" "
+    full+="${group_labels[$gi]} ${group_times[$gi]}"
+    short+="${group_times[$gi]}"
+  done
+  printf '%s\n' "$full"   # full_text
+  printf '%s\n' "$short"  # short_text (no color line -> inherits bar default)
+}
+
+case "${1:-}" in
+  __render) render ;;
+  *)        render ;;
+esac
+exit 0

--- a/i3/docs/2026-06-01-worldclock-blocklet-design.md
+++ b/i3/docs/2026-06-01-worldclock-blocklet-design.md
@@ -1,0 +1,104 @@
+# i3blocks: world-clock blocklet — design
+
+**Date:** 2026-06-01
+**Host:** hexane
+**Repo:** `issmirnov/dotfiles` (public) — script lives in `i3/blocklets/`, wired via `i3/i3blocks.conf`
+
+## Goal
+
+Add a world-clock segment to the hexane i3blocks bar showing the live time in **Zagreb,
+Prague, and Kyiv**. hexane runs on `America/Denver`, so the existing `[time]` block already
+covers local time; this block adds the three European cities (≈8–9h ahead).
+
+Among the three there are only **two distinct offsets**: Zagreb and Prague are both Central
+European Time (UTC+1 winter / +2 summer) and always show the *same* clock; Kyiv is Eastern
+European Time (UTC+2 / +3), exactly one hour ahead. Both zones switch DST on the same dates,
+so the 1-hour gap holds year-round and Zagreb always equals Prague.
+
+## Rendering decision
+
+Render **`ZAG·PRG 21:03  KYV 22:03`** — cities that currently show the same time are
+collapsed under a joined label, groups separated by two spaces. 24-hour, DST-aware.
+
+Chosen (over listing all three explicitly, flags, or bare TZ names) because the user
+explicitly flagged the shared-timezone redundancy: collapsing avoids printing the identical
+Zagreb/Prague number twice while still naming every city. The collapse is computed from the
+*actual* rendered times rather than hardcoded, so it always reflects reality — DST-correct,
+and it would split automatically in the (practically impossible) event the offsets diverged.
+
+Plain text, **no icon** (matches the chosen style; zero font-rendering risk). No color line,
+so the segment inherits the bar default like the neighbouring `[time]` block.
+
+## Component — `blocklets/worldclock`
+
+Single script, same conventions as `ai_usage` / `network`:
+
+- **Cities** — an ordered `label|tz` list, west-to-east by offset:
+  `ZAG|Europe/Zagreb`, `PRG|Europe/Prague`, `KYV|Europe/Kiev`.
+- **Render logic** — for each city compute `HH:MM` via `TZ=$tz date +%H:%M`; group the
+  cities that share an identical `HH:MM` (preserving first-appearance order); join each
+  group's labels with `·`; join groups with two spaces. Today → `ZAG·PRG 21:03  KYV 22:03`.
+- **Output (i3blocks 3-line protocol):**
+  - `full_text`: `ZAG·PRG 21:03  KYV 22:03`
+  - `short_text`: the distinct times only, space-joined — `21:03 22:03` (drops labels when
+    the bar is cramped)
+  - *(no color line — inherit default)*
+- **Test seam** — `WORLDCLOCK_NOW=<epoch seconds>`, when set, pins "now" so every `date`
+  call renders that fixed instant (`TZ=$tz date -d "@$WORLDCLOCK_NOW" +%H:%M`). Lets tests
+  assert exact strings deterministically across DST boundaries. Unset → real current time.
+- **Dispatch verb** — `__render` prints the three protocol lines to stdout (the hook the
+  tests drive), mirroring `ai_usage`'s hidden verbs.
+- **Robustness** — pure `date`; no network, no files, no secrets. Always `exit 0` so it can
+  never break the bar. (No failure modes beyond a missing `date`/tz database, which would be
+  a broken system; in that case it still exits 0 with whatever `date` emits.)
+
+### Config (`i3/i3blocks.conf`)
+
+```ini
+[worldclock]
+command=$SCRIPT_DIR/worldclock
+interval=30
+```
+
+Inserted just **before `[time]`**, so the bar's right end reads `… worldclock, time` — the
+remote clocks sit immediately left of the local clock. `interval=30`: the display is
+minute-granular and `date` is effectively free, so 30 s keeps worst-case skew under half a
+minute at negligible cost (trivially tunable; could match `[time]`'s `5` for lockstep ticks).
+`~/.i3blocks.conf` is a symlink to this file, so editing the repo file is the deployed change.
+
+## Tests — `blocklets/tests/test_worldclock.sh`
+
+Auto-discovered by `tests/run.sh` (globs `test_*.sh`). Drives `__render` with
+`WORLDCLOCK_NOW` pinned to fixed UTC instants, asserting exact output:
+
+- **Summer instant** (e.g. `2026-07-01 12:00 UTC`): Zagreb/Prague +2, Kyiv +3 →
+  `full_text` = `ZAG·PRG 14:00  KYV 15:00`; `short_text` = `14:00 15:00`.
+- **Winter instant** (e.g. `2026-01-15 12:00 UTC`): Zagreb/Prague +1, Kyiv +2 →
+  `full_text` = `ZAG·PRG 13:00  KYV 14:00`. Same UTC time, different display ⇒ proves the
+  block is DST-aware, ZAG·PRG stays collapsed, and Kyiv stays exactly +1h in both seasons.
+- **Collapse invariant**: in both fixtures Zagreb and Prague share one `ZAG·PRG` group and
+  the output contains exactly two time tokens.
+
+Fixed-instant epochs are derived in-test with `date -u -d '<iso>' +%s` (no hardcoded magic
+numbers), so the suite stays dependency-free and offline like the rest of the harness.
+
+## Key-leakage safeguards
+
+None needed — the script reads no credentials and emits only city labels and clock times.
+Recorded here only to stay consistent with the other blocklet docs: this block touches no
+files under `$HOME` and writes nothing to the repo.
+
+## Verification plan
+
+- `i3/blocklets/worldclock __render` → three lines, `ZAG·PRG HH:MM  KYV HH:MM` matching the
+  current real time in those cities.
+- `WORLDCLOCK_NOW=$(date -u -d '2026-07-01 12:00 UTC' +%s) i3/blocklets/worldclock __render`
+  → `ZAG·PRG 14:00  KYV 15:00`.
+- `bash i3/blocklets/tests/run.sh` → all suites green (existing + new).
+- `i3-msg restart` → eyeball the new segment immediately left of the local clock.
+
+## Out of scope (YAGNI)
+
+- Click actions, seconds, date-per-city, configurable city list (hardcoded three is the ask).
+- An icon/label (explicitly chosen plain).
+- Signalling i3blocks on the exact minute boundary (interval polling is sufficient).

--- a/i3/docs/2026-06-01-worldclock-blocklet-design.md
+++ b/i3/docs/2026-06-01-worldclock-blocklet-design.md
@@ -60,10 +60,10 @@ command=$SCRIPT_DIR/worldclock
 interval=30
 ```
 
-Inserted just **before `[time]`**, so the bar's right end reads `… worldclock, time` — the
-remote clocks sit immediately left of the local clock. `interval=30`: the display is
-minute-granular and `date` is effectively free, so 30 s keeps worst-case skew under half a
-minute at negligible cost (trivially tunable; could match `[time]`'s `5` for lockstep ticks).
+Inserted as the **first (leftmost) block, before `[bt_vol]`**, so the bar's left end reads
+`worldclock, bt_vol, …`. `interval=30`: the display is minute-granular and `date` is
+effectively free, so 30 s keeps worst-case skew under half a minute at negligible cost
+(trivially tunable; could match `[time]`'s `5` for lockstep ticks).
 `~/.i3blocks.conf` is a symlink to this file, so editing the repo file is the deployed change.
 
 ## Tests — `blocklets/tests/test_worldclock.sh`
@@ -95,7 +95,7 @@ files under `$HOME` and writes nothing to the repo.
 - `WORLDCLOCK_NOW=$(date -u -d '2026-07-01 12:00 UTC' +%s) i3/blocklets/worldclock __render`
   → `ZAG·PRG 14:00  KYV 15:00`.
 - `bash i3/blocklets/tests/run.sh` → all suites green (existing + new).
-- `i3-msg restart` → eyeball the new segment immediately left of the local clock.
+- `i3-msg restart` → eyeball the new segment at the far left of the bar (before the 🎧 block).
 
 ## Out of scope (YAGNI)
 

--- a/i3/docs/2026-06-01-worldclock-blocklet-plan.md
+++ b/i3/docs/2026-06-01-worldclock-blocklet-plan.md
@@ -155,22 +155,22 @@ git commit -m "feat(i3): worldclock blocklet (Zagreb/Prague/Kyiv)"
 ### Task 4: Wire into the bar + deploy locally
 
 **Files:**
-- Modify: `i3/i3blocks.conf` (insert before `[time]`, currently line 88)
+- Modify: `i3/i3blocks.conf` (insert as the first block, before `[bt_vol]`)
 
-- [ ] **Step 1: Insert the block immediately before `[time]`**
+- [ ] **Step 1: Insert the block as the first block, before `[bt_vol]`**
 
 ```ini
 [worldclock]
 command=$SCRIPT_DIR/worldclock
 interval=30
 
-[time]
+[bt_vol]
 ```
 
 - [ ] **Step 2: Deploy in place**
 
 Run: `i3-msg restart`
-Expected: `[{"success":true}]`; the bar reloads, new segment appears immediately left of the local clock.
+Expected: `[{"success":true}]`; the bar reloads, new segment appears at the far left (before the 🎧 block).
 
 - [ ] **Step 3: Eyeball the live segment**
 
@@ -181,7 +181,7 @@ Expected: `ZAG·PRG HH:MM  KYV HH:MM` matching the real current time in those ci
 
 ```bash
 git add i3/i3blocks.conf
-git commit -m "feat(i3): wire worldclock block before [time]"
+git commit -m "feat(i3): wire worldclock as the first (leftmost) block"
 ```
 
 ---
@@ -220,7 +220,7 @@ git commit -m "docs(i3): document worldclock blocklet in README"
 
 ## Self-Review
 
-- **Spec coverage:** collapse-by-equal-time render (T2), full+short output (T2), `WORLDCLOCK_NOW`/`__render` seam (T2), summer+winter+invariant tests (T1/T3), config before `[time]` interval=30 (T4), README (T5), design doc already committed. ✓
+- **Spec coverage:** collapse-by-equal-time render (T2), full+short output (T2), `WORLDCLOCK_NOW`/`__render` seam (T2), summer+winter+invariant tests (T1/T3), config as first block before `[bt_vol]` interval=30 (T4), README (T5), design doc already committed. ✓
 - **Placeholders:** none — every code/command step is concrete.
 - **Type consistency:** test references `$S/../worldclock` and `__render`; script defines `__render` + default both calling `render`; label spelling `ZAG/PRG/KYV` and `·` separator consistent across script, tests, README, design doc. ✓
 - **DST correctness:** summer (UTC+2/+3 → 14:00/15:00) and winter (UTC+1/+2 → 13:00/14:00) verified against the tz rules; fixed UTC epochs make assertions host-TZ-independent.

--- a/i3/docs/2026-06-01-worldclock-blocklet-plan.md
+++ b/i3/docs/2026-06-01-worldclock-blocklet-plan.md
@@ -1,0 +1,226 @@
+# Worldclock Blocklet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an i3blocks segment showing live time in Zagreb, Prague, and Kyiv, collapsing cities that share a clock (`ZAG·PRG 21:03  KYV 22:03`).
+
+**Architecture:** One self-contained bash script (`i3/blocklets/worldclock`) that computes each city's `HH:MM` via `TZ=… date`, groups cities with identical times, and prints the i3blocks full_text/short_text lines. A `WORLDCLOCK_NOW=<epoch>` seam pins "now" for deterministic, DST-spanning tests. Wired into `i3blocks.conf` before `[time]`.
+
+**Tech Stack:** bash, coreutils `date` (tz database), the repo's existing dependency-free `tests/assert.sh` harness.
+
+---
+
+### Task 1: Failing test — summer instant
+
+**Files:**
+- Test: `i3/blocklets/tests/test_worldclock.sh` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+#!/usr/bin/env bash
+DIR=$(dirname "$0"); . "$DIR/assert.sh"; S="$DIR/../worldclock"
+
+# Fixed UTC instants -> deterministic regardless of host TZ.
+# Summer: 2026-07-01 12:00 UTC -> Zagreb/Prague +2 (14:00), Kyiv +3 (15:00)
+summer=$(date -u -d '2026-07-01 12:00:00' +%s)
+out=$(WORLDCLOCK_NOW=$summer bash "$S" __render)
+assert_eq "summer full"  "ZAG·PRG 14:00  KYV 15:00" "$(sed -n 1p <<<"$out")"
+assert_eq "summer short" "14:00 15:00"              "$(sed -n 2p <<<"$out")"
+finish
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash i3/blocklets/tests/test_worldclock.sh`
+Expected: FAIL — `worldclock` does not exist yet (`No such file or directory` / empty output mismatch).
+
+---
+
+### Task 2: Implement the script — make summer pass
+
+**Files:**
+- Create: `i3/blocklets/worldclock` (mode 0755)
+
+- [ ] **Step 1: Write minimal implementation**
+
+```bash
+#!/usr/bin/env bash
+# worldclock — i3blocks segment: live time in Zagreb, Prague, Kyiv.
+# Zagreb & Prague share CET (always equal); Kyiv is EET (+1h). Cities whose
+# current HH:MM match are collapsed under a joined label. Pure date/TZ — no
+# network, no secrets, always exits 0. Test seam: WORLDCLOCK_NOW=<epoch> pins now.
+set -u
+
+# label|tz, ordered west-to-east by offset
+CITIES=(
+  "ZAG|Europe/Zagreb"
+  "PRG|Europe/Prague"
+  "KYV|Europe/Kiev"
+)
+
+time_in() {  # <tz> -> HH:MM at the current (or pinned) instant
+  local tz=$1
+  if [ -n "${WORLDCLOCK_NOW:-}" ]; then
+    TZ="$tz" date -d "@$WORLDCLOCK_NOW" +%H:%M
+  else
+    TZ="$tz" date +%H:%M
+  fi
+}
+
+render() {
+  local entry lab tz i gi found
+  local labels=() times=()
+  for entry in "${CITIES[@]}"; do
+    lab=${entry%%|*}; tz=${entry#*|}
+    labels+=("$lab"); times+=("$(time_in "$tz")")
+  done
+  # group cities by equal time, preserving first-appearance order
+  local group_times=() group_labels=()
+  for i in "${!times[@]}"; do
+    found=-1
+    for gi in "${!group_times[@]}"; do
+      [ "${group_times[$gi]}" = "${times[$i]}" ] && { found=$gi; break; }
+    done
+    if [ "$found" -ge 0 ]; then
+      group_labels[$found]="${group_labels[$found]}·${labels[$i]}"
+    else
+      group_times+=("${times[$i]}"); group_labels+=("${labels[$i]}")
+    fi
+  done
+  local full="" short=""
+  for gi in "${!group_times[@]}"; do
+    [ -n "$full" ]  && full+="  "
+    [ -n "$short" ] && short+=" "
+    full+="${group_labels[$gi]} ${group_times[$gi]}"
+    short+="${group_times[$gi]}"
+  done
+  printf '%s\n' "$full"   # full_text
+  printf '%s\n' "$short"  # short_text (no color line -> inherits bar default)
+}
+
+case "${1:-}" in
+  __render) render ;;
+  *)        render ;;
+esac
+exit 0
+```
+
+- [ ] **Step 2: Make executable**
+
+Run: `chmod +x i3/blocklets/worldclock`
+
+- [ ] **Step 3: Run test to verify summer passes**
+
+Run: `bash i3/blocklets/tests/test_worldclock.sh`
+Expected: PASS (summer full + short).
+
+---
+
+### Task 3: Add winter + collapse invariant — prove DST
+
+**Files:**
+- Modify: `i3/blocklets/tests/test_worldclock.sh`
+
+- [ ] **Step 1: Add assertions before `finish`**
+
+```bash
+# Winter: 2026-01-15 12:00 UTC -> Zagreb/Prague +1 (13:00), Kyiv +2 (14:00).
+# Same UTC instant, different display => DST-aware; ZAG·PRG stays collapsed, KYV +1h.
+winter=$(date -u -d '2026-01-15 12:00:00' +%s)
+wout=$(WORLDCLOCK_NOW=$winter bash "$S" __render)
+assert_eq "winter full"  "ZAG·PRG 13:00  KYV 14:00" "$(sed -n 1p <<<"$wout")"
+assert_eq "winter short" "13:00 14:00"              "$(sed -n 2p <<<"$wout")"
+
+# Collapse invariant: exactly two time tokens (ZAG·PRG share one, KYV the other).
+assert_contains "summer collapses ZAG·PRG" "ZAG·PRG" "$(sed -n 1p <<<"$out")"
+ntok=$(sed -n 2p <<<"$out" | tr ' ' '\n' | grep -c ':')
+assert_eq "summer has two time tokens" "2" "$ntok"
+```
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `bash i3/blocklets/tests/run.sh`
+Expected: every suite green, including the 6 new `test_worldclock` assertions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add i3/blocklets/worldclock i3/blocklets/tests/test_worldclock.sh
+git commit -m "feat(i3): worldclock blocklet (Zagreb/Prague/Kyiv)"
+```
+
+---
+
+### Task 4: Wire into the bar + deploy locally
+
+**Files:**
+- Modify: `i3/i3blocks.conf` (insert before `[time]`, currently line 88)
+
+- [ ] **Step 1: Insert the block immediately before `[time]`**
+
+```ini
+[worldclock]
+command=$SCRIPT_DIR/worldclock
+interval=30
+
+[time]
+```
+
+- [ ] **Step 2: Deploy in place**
+
+Run: `i3-msg restart`
+Expected: `[{"success":true}]`; the bar reloads, new segment appears immediately left of the local clock.
+
+- [ ] **Step 3: Eyeball the live segment**
+
+Run: `BLOCK_INSTANCE= i3/blocklets/worldclock` and compare to the bar.
+Expected: `ZAG·PRG HH:MM  KYV HH:MM` matching the real current time in those cities.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add i3/i3blocks.conf
+git commit -m "feat(i3): wire worldclock block before [time]"
+```
+
+---
+
+### Task 5: Document in the blocklets README
+
+**Files:**
+- Modify: `i3/blocklets/README.md` (add a `worldclock` section after `network`)
+
+- [ ] **Step 1: Add the section**
+
+```markdown
+## `worldclock` — Zagreb / Prague / Kyiv
+
+Single block (`[worldclock]`, `interval=30`). Prints the live time in three cities,
+collapsing those that share a clock:
+
+```
+ZAG·PRG 21:03  KYV 22:03
+```
+
+Zagreb and Prague are both Central European Time (always equal); Kyiv is one hour ahead
+(Eastern European Time). Grouping is computed from the actual rendered times, so it's
+DST-aware and self-correcting. Pure `date`/`TZ` — no network, no secrets. The
+`WORLDCLOCK_NOW=<epoch>` seam pins "now" for the deterministic summer/winter tests.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add i3/blocklets/README.md
+git commit -m "docs(i3): document worldclock blocklet in README"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** collapse-by-equal-time render (T2), full+short output (T2), `WORLDCLOCK_NOW`/`__render` seam (T2), summer+winter+invariant tests (T1/T3), config before `[time]` interval=30 (T4), README (T5), design doc already committed. ✓
+- **Placeholders:** none — every code/command step is concrete.
+- **Type consistency:** test references `$S/../worldclock` and `__render`; script defines `__render` + default both calling `render`; label spelling `ZAG/PRG/KYV` and `·` separator consistent across script, tests, README, design doc. ✓
+- **DST correctness:** summer (UTC+2/+3 → 14:00/15:00) and winter (UTC+1/+2 → 13:00/14:00) verified against the tz rules; fixed UTC epochs make assertions host-TZ-independent.

--- a/i3/i3blocks.conf
+++ b/i3/i3blocks.conf
@@ -56,7 +56,7 @@ interval=5
 [cpu_usage]
 # https://fontawesome.com/icons/microchip?style=solid
 label=
-interval=5cont
+interval=5
 min_width=100.00%
 
 
@@ -94,4 +94,4 @@ interval=1200
 # https://fontawesome.com/icons/calendar-alt?style=regular
 label=
 command= date '+%a %b %d %H:%M'
-interval=5cont
+interval=5

--- a/i3/i3blocks.conf
+++ b/i3/i3blocks.conf
@@ -36,6 +36,11 @@ interval=1
 # min_width=long_space_here_                                                                                         _voila
 # align=center
 
+# World clock: Zagreb / Prague / Kyiv (cities sharing a clock collapse together)
+[worldclock]
+command=$SCRIPT_DIR/worldclock
+interval=30
+
 [bt_vol]
 label=🎧
 interval=180


### PR DESCRIPTION
## Summary
- New custom blocklet `i3/blocklets/worldclock` showing live time in **Zagreb, Prague, and Kyiv** as the **leftmost** bar segment.
- Renders `ZAG·PRG 21:03  KYV 22:03` — cities that currently share a clock are **collapsed by equal time** (Zagreb/Prague are both CET and always equal; Kyiv is +1h EET). Grouping is computed from the actual rendered times, so it's DST-aware and self-correcting.
- Pure `date`/`TZ` — no network, no secrets, always `exit 0`. `full_text` shows labelled groups; `short_text` drops labels (`21:03 22:03`); no color line (inherits bar default, like `[time]`).
- `WORLDCLOCK_NOW=<epoch>` test seam + `__render` dispatch verb, matching the `ai_usage`/`network` conventions.
- Wired into `i3blocks.conf` (`interval=30`), documented in `blocklets/README.md`, with a design doc + implementation plan under `i3/docs/`.

## Test Plan
- [x] `bash i3/blocklets/tests/run.sh` — all suites green (6 new `test_worldclock` assertions + 53 existing = 59, 0 failures)
- [x] Summer instant (`2026-07-01 12:00 UTC`) → `ZAG·PRG 14:00  KYV 15:00`
- [x] Winter instant (`2026-01-15 12:00 UTC`) → `ZAG·PRG 13:00  KYV 14:00` (same UTC instant, different display ⇒ DST-aware; ZAG·PRG stays collapsed, KYV stays +1h)
- [x] Collapse invariant: exactly two time tokens, ZAG·PRG share one group
- [x] Deployed live via `i3-msg restart`; verified leftmost segment matches real current time

🤖 Generated with [Claude Code](https://claude.com/claude-code)