### PR TITLE
tmux: OSC 52 remote clipboard over SSH + native mouse scroll

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -56,21 +56,26 @@ set -g default-terminal screen-256color
 # New windows/pane in $PWD
 bind c new-window -c "#{pane_current_path}"
 
-# Enable mouse
+# Enable mouse: click a pane/window to select, drag a border to resize, drag to
+# copy. Wheel scrolling is left to tmux's native binding (forwards to vim/less,
+# else copy-mode scrollback); the old hand-rolled override was removed 2026-07-12.
 set -g mouse on
 
-# Fix mouse scrolling in scholl mode (Prefix+"[")
-bind -n WheelUpPane if-shell -Ft= '#{?pane_in_mode,1,#{mouse_any_flag}}' \
-        'send -Mt=' 'if-shell -Ft= "#{alternate_on}" \
-        "send -t= Up" "copy-mode -et="'
-bind -n WheelDownPane if-shell -Ft = '#{?pane_in_mode,1,#{mouse_any_flag}}' \
-        'send -Mt=' 'if-shell -Ft= "#{alternate_on}" \
-        "send -t= Down" "send -Mt="'
+# Remote clipboard over SSH: set-clipboard "on" makes tmux emit OSC 52 on copy,
+# so yanks reach the LOCAL clipboard even when tmux runs on a remote host (the
+# default "external" only accepts OSC 52, never sends it). Needs an OSC 52-aware
+# terminal — Alacritty has osc52 = "CopyPaste". '*' covers non-xterm TERM values.
+set -s set-clipboard on
+set -ag terminal-features ',*:clipboard'
 
-# enable yanking to remote clipboards.
+# Local clipboard integration via tmux-yank (xclip on Linux / pbcopy on macOS).
 # https://github.com/tmux-plugins/tmux-yank#controlling-yank-behavior
-run-shell ~/.dotfiles/tmux/plugins/tmux-yank/yank.tmux
+# NOTE: these @-options MUST be set BEFORE run-shell — the plugin binds its copy
+# keys as it loads, so an override set afterwards is ignored and it falls back to
+# auto-detection (which picks wl-copy on this box, broken under X11). Remote /
+# over-SSH clipboards are handled by the OSC 52 block above; this is the local path.
 if-shell 'test "$(uname)" = "Darwin"' \
-    'set -g @override_copy_command "cat | head -c -1 | nc -q1 localhost 2224"' \
+    'set -g @override_copy_command "pbcopy"' \
     'set -g @override_copy_command "xclip -selection clipboard -i"'
-set -g @yank_with_mouse on # or 'on'
+set -g @yank_with_mouse on
+run-shell ~/.dotfiles/tmux/plugins/tmux-yank/yank.tmux


### PR DESCRIPTION
## What

Makes tmux mouse, scroll, and clipboard behave correctly — including **remote clipboard over SSH** via OSC 52.

- **Remote clipboard over SSH (new):** `set-clipboard on` + a `*:clipboard` terminal-feature make tmux emit an OSC 52 escape on copy, so yanks land in the **local** clipboard even when tmux is running on a remote host you've SSH'd into. Alacritty is already configured with `osc52 = "CopyPaste"`, so the receiving side works today. tmux's default (`external`) only *accepts* OSC 52 from apps and never sends it out — hence copies never reached the local clipboard before.
- **Native scroll:** removed the hand-rolled 2019 `WheelUp/DownPane` override. tmux 3.x's built-in wheel binding already forwards the wheel to alternate-screen apps (vim/less) and enters copy-mode scrollback otherwise, so the override was redundant.
- **Latent `tmux-yank` bug fixed:** `@override_copy_command` was set *after* `run-shell …/yank.tmux`, so the plugin never saw it and auto-detected `wl-copy` — which is broken on this X11 box (no Wayland socket). Moved the override (and `@yank_with_mouse`) *before* `run-shell` so `xclip` is actually used on Linux. Confirmed on the live tmux server that `y`/mouse-drag were bound to `wl-copy` before this change.
- **Retired the dead macOS `nc localhost 2224` scheme** in favor of `pbcopy` (already the effective macOS default, since the old override was ignored). OSC 52 now covers the remote case that `nc` used to. **No behavior change on macOS.**

Mouse click / drag-to-select / drag-to-resize was already on via `set -g mouse on` and is unchanged.

## Verification

Sourced the edited config on a throwaway tmux server (`tmux -L … -f tmux.conf`) and confirmed:

- config sources without error
- `set-clipboard = on`; `terminal-features` carries `*:clipboard` (plus built-in `xterm*:clipboard`)
- `mouse = on`
- `WheelUpPane` = native default (`copy-mode -e`); old `send -t= Up` hack gone
- `y` / `MouseDragEnd1Pane` now pipe to `xclip -selection clipboard -i` (was `wl-copy`)

## Test plan (local, needs a real Alacritty)

- [ ] Reload: `tmux source-file ~/.tmux.conf` (clipboard applies live).
- [ ] **Scroll change needs a fresh server** — `tmux kill-server` or next login — since re-sourcing doesn't shed the already-bound override.
- [ ] Local copy: select with mouse / `y` in copy-mode → paste into another app.
- [ ] Remote copy: `ssh` into a box running this same tmux, copy in a pane → confirm it lands in the local clipboard (this is the OSC 52 path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
