### PR TITLE
install: create ~/bin and local zsh state files before linking

### DIFF
--- a/install
+++ b/install
@@ -10,6 +10,11 @@ BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${BASEDIR}"
 git submodule update --init --recursive "${DOTBOT_DIR}"
 
+# Prereqs: ensure targets exist before dotbot links into them.
+mkdir -p "${HOME}/bin"                                                 # ~/bin/* symlinks need the dir to populate
+[ -f "${HOME}/.zshrc.local" ] || touch "${HOME}/.zshrc.local"          # local zsh overrides sourced by ~/.zshrc
+[ -f "${HOME}/.zsh_history_ext" ] || touch "${HOME}/.zsh_history_ext"  # per-dir cmd log appended by jog()
+
 # base lib
 "${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" -c "default${CONFIG_SUFFIX}"
 


### PR DESCRIPTION
## What

The `install` script now creates a few prerequisites up front, right after the submodule update and before dotbot links anything:

- `mkdir -p ~/bin` — several entries symlink *into* `~/bin` (`~/bin/tm`, `~/bin/dotbin`, `~/bin/hop`, `~/bin/i3_switch_workspace.sh`, and `~/bin/lock` on macOS), so the directory needs to exist first for linking to populate it.
- `touch ~/.zshrc.local` — `zsh/zshrc` sources `~/.zshrc.local` for local overrides and lists it in `ZGEN_RESET_ON_CHANGE`. On a fresh machine this file doesn't exist, so it had to be created by hand.
- `touch ~/.zsh_history_ext` — `zsh/config/jog.zsh` appends a per-directory command log here via the `zshaddhistory` hook. Its own comment notes the first run requires `touch ~/.zsh_history_ext` and that it deliberately doesn't self-check on every command (too slow).

## Why guarded touches

Both touches use `[ -f ... ] || touch ...` so they only create when missing:

- `~/.zshrc.local` is in `ZGEN_RESET_ON_CHANGE` — an unconditional `touch` would bump its mtime every install and force a full zgen plugin rebuild on the next shell start.
- `~/.zsh_history_ext` is an append-only log — the guard guarantees an existing history is never at risk.

## Verification

- `bash -n install` parses cleanly.
- Ran the block against a throwaway `$HOME`: `~/bin`, `~/.zshrc.local`, and `~/.zsh_history_ext` are created on first run; re-runs are idempotent with `~/.zshrc.local`'s mtime unchanged; and a pre-existing `~/.zsh_history_ext` keeps its contents untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)