### PR TITLE
fonts: strip ASCII/Latin from Noto Color Emoji charset (fix Arch font gaps)

### DIFF
--- a/fonts/fonts.conf
+++ b/fonts/fonts.conf
@@ -2,22 +2,39 @@
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
 
-  <match target="pattern">
-    <test name="prgname"><string>chrome</string></test>
-    <edit name="family" mode="prepend_first">
-      <string>Noto Color Emoji</string>
+  <!-- Strip ASCII/Latin (U+0000-U+02FF: space, digits, '#', '*', (c), (r), ...)
+       from Noto Color Emoji's charset at scan time. Noto Color Emoji renders
+       these at emoji em-width, so whenever it wins the fallback for them the
+       result is giant word gaps ("My      Media", "TV      shows") and
+       oversized digits in Chrome/Electron. Removing them from its charset
+       guarantees plain text chars always come from the primary text font, no
+       matter how highly Noto is ranked below it. Real emoji (>= U+0300, incl.
+       ZWJ U+200D and combining keycap U+20E3) are left untouched. -->
+  <match target="scan">
+    <test name="family"><string>Noto Color Emoji</string></test>
+    <edit name="charset" mode="assign">
+      <minus>
+        <name>charset</name>
+        <charset>
+          <range><int>0x0</int><int>0x2FF</int></range>
+        </charset>
+      </minus>
     </edit>
   </match>
 
-  <!-- Universal color-emoji fallback (fixes Alacritty & other terminals).
-       Font Awesome 7 (otf-font-awesome) squats on real emoji codepoints
-       (U+1F534 red, U+1F7E1 yellow, U+1F7E2 green circles, plus many more)
-       and fontconfig ranks its monochrome outline glyphs ABOVE Noto Color
-       Emoji, so emoji render as hollow gray rings. Appending Noto Color
-       Emoji as a strong-bound family makes it win the fallback for glyphs
-       the primary font lacks, while APPEND (not prepend) keeps normal text
-       — including digits, '#', '*' that Noto also contains — on the primary
-       font, and apps that explicitly request "Font Awesome" still get it. -->
+  <!-- Color-emoji fallback. Font Awesome 7 (otf-font-awesome) squats real
+       emoji codepoints (U+1F534 red, U+1F7E1 yellow, U+1F7E2 green circles,
+       plus many more; its charset spans U+0020-U+052F and into the emoji
+       planes) and fontconfig otherwise ranks its monochrome outline glyphs
+       ABOVE Noto Color Emoji, so emoji render as hollow gray rings. A STRONG
+       append puts Noto Color Emoji into every family list high enough to win
+       the fallback for emoji glyphs the primary font lacks. Strong is safe for
+       text ONLY because the scan rule above stripped ASCII/Latin from Noto, so
+       it can no longer be selected for space or digits.
+
+       Verify: `fc-match sans-serif`               -> DejaVu Sans (text font)
+               `fc-match sans-serif:charset=1f534`  -> Noto Color Emoji
+       Never let `fc-match sans-serif` return "Noto Color Emoji" again. -->
   <match target="pattern">
     <edit name="family" mode="append" binding="strong">
       <string>Noto Color Emoji</string>

--- a/ubuntu.conf.yaml
+++ b/ubuntu.conf.yaml
@@ -35,4 +35,7 @@
 
 
 - shell:
-    - ['([ -x "$(command -v fc-cache)" ] && fc-cache -f -v ~/.fonts) || echo "no fc-cache command"', "Regenerate font cache."]
+    # Rebuild ALL font caches, not just ~/.fonts: the Noto Color Emoji scan-strip in
+    # fonts/fonts.conf must also apply to the system copy (/usr/share/fonts/noto, from
+    # noto-fonts-emoji) or that copy keeps space/digits and the word-gaps persist.
+    - ['([ -x "$(command -v fc-cache)" ] && fc-cache -f -v) || echo "no fc-cache command"', "Regenerate all font caches."]


### PR DESCRIPTION
## Problem

On Arch, `Noto Color Emoji` was winning fontconfig fallback for plain ASCII (space, digits, `#`, `*`) and rendering them at emoji em-width — giant word gaps ("My&nbsp;&nbsp;&nbsp;&nbsp;Media", "TV&nbsp;&nbsp;&nbsp;&nbsp;shows") and oversized digits in Chrome/Electron.

## Fix

**`fonts/fonts.conf`** — two rules:
1. **`target="scan"`** — subtract `U+0000–U+02FF` from Noto Color Emoji's charset at scan time, so it can never be selected for space/digits/punctuation regardless of ranking. Real emoji (`≥ U+0300`, incl. ZWJ `U+200D` and keycap combiner `U+20E3`) untouched.
2. **`target="pattern"` strong append** — puts Noto Color Emoji high enough in every family list to win fallback for emoji the primary font lacks. Strong is safe *only because* rule 1 stripped ASCII/Latin from Noto. Also fixes Font Awesome 7 squatting real emoji codepoints (hollow gray rings → color). Replaces the old chrome-only `prepend_first` hack, so Alacritty and other terminals are fixed too.

**`ubuntu.conf.yaml`** — the installer's font-cache step was `fc-cache -f -v ~/.fonts`, which rescans **only** the user font dir. Arch's `noto-fonts-emoji` ships a *second* copy at `/usr/share/fonts/noto/NotoColorEmoji.ttf` that the scan-strip never reaches, so on a fresh machine that copy keeps space/digits and the gaps persist. Dropped the `~/.fonts` restriction → `fc-cache -f -v` now rebuilds **every** configured dir with the scan rule active. (Addresses the Codex P2 on the scan edit.)

### Verify
```
fc-match sans-serif:charset=20      -> DejaVu Sans   (space -> text font)
fc-match sans-serif:charset=30      -> DejaVu Sans   (digit -> text font)
fc-match sans-serif:charset=1f534   -> Noto Color Emoji
```

## Known cosmetic tradeoff (accepted)

The `U+0000–U+02FF` strip also covers the *bases* for a few text-presentation emoji, so these render **monochrome**: `©️` (U+00A9), `®️` (U+00AE), and keycaps `1️⃣`/`#️⃣`/`*️⃣` (bases `0x23`/`0x2A`/`0x30–0x39`). This is deliberate — re-adding the digit/`#`/`*` bases would let strong-appended Noto win *bare* digits again and reintroduce the word-gap bug (fontconfig charset ops are per-codepoint and can't tell a bare digit from a keycap base). The gap bug is far worse; these sequences are rare; fonts render correctly in daily use on Arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)