### PR TITLE
yabai/skhd: focus-follows-mouse, resize mode, stacks, and cleanup

### DIFF
--- a/borders/README.md
+++ b/borders/README.md
@@ -1,0 +1,44 @@
+# borders — JankyBorders
+
+Draws the colored outline around windows — the **active-window highlight** for the
+[yabai](../yabai/README.md) tiling setup. Without it, there's no visual cue for which
+window is focused.
+
+## Why this exists
+
+yabai used to draw window borders itself, but that was **removed in yabai v6.0.0**
+(along with every `window_border*` / `*_border_color` config option). The author split
+it out into a standalone tool, **[JankyBorders](https://github.com/FelixKratz/JankyBorders)**
+(`borders`), which this folder configures.
+
+Unlike yabai's scripting addition, borders needs **no SIP changes and no scripting
+addition** — it uses public macOS APIs, so it works even with SIP fully enabled (which is
+the case on this machine — see the SIP notes in [`../yabai/README.md`](../yabai/README.md)).
+
+## Install
+
+```sh
+brew install FelixKratz/formulae/borders   # the borders binary (its own Homebrew tap)
+brew services start borders                # run it as a login service
+```
+
+Manage it with `brew services restart|stop borders`.
+
+## How it's wired
+
+- **`bordersrc`** — the config (colors, width, style). dotbot symlinks it to
+  `~/.config/borders/bordersrc` (see the link in [`../osx.conf.yaml`](../osx.conf.yaml)),
+  which is where the `borders` daemon looks for it. It must stay executable — the daemon
+  runs it as a script on startup.
+- Colors mirror the old built-in yabai borders: **orange active** (`0xffffa500`),
+  **grey inactive** (`0xff505050`), width `6`, `round` style.
+- The skhd **resize mode** flips the active color to **red** (`0xffff3b30`) as a mode
+  indicator — see the `:: resize` mode block in [`../skhd/base`](../skhd/base). That's why
+  editing colors here should stay in sync with those two lines.
+
+## Files
+
+| Path | What |
+|------|------|
+| `bordersrc` | borders config — executable; run by the `borders` daemon on start |
+| `~/.config/borders/bordersrc` | dotbot symlink → this folder (created by `osx.conf.yaml`) |

--- a/borders/bordersrc
+++ b/borders/bordersrc
@@ -1,0 +1,15 @@
+#!/bin/bash
+# JankyBorders config — replaces yabai's built-in window borders (removed in v6.0.0).
+# Recreates your previous yabai border look. Runs as a brew service:
+#   brew services start borders
+# Reference: https://github.com/FelixKratz/JankyBorders
+
+options=(
+    style=round
+    width=6.0
+    hidpi=off
+    active_color=0xffffa500   # orange — matches your old active_window_border_color
+    inactive_color=0xff505050 # grey  — matches your old normal_window_border_color
+)
+
+borders "${options[@]}"

--- a/osx.conf.yaml
+++ b/osx.conf.yaml
@@ -10,6 +10,7 @@
 - link:
     "~/Library/Application Support/Übersicht/widgets": ubersicht
     ~/.config/karabiner/karabiner.json: karabiner/karabiner.json
+    ~/.config/borders/bordersrc: borders/bordersrc
     ~/.skhdrc: skhd/skhdrc.generated
     ~/.yabairc: yabai/yabairc
     ~/Library/Fonts/Inconsolata-Regular.ttf: fonts/Inconsolata-Regular.ttf

--- a/skhd/base
+++ b/skhd/base
@@ -1,88 +1,117 @@
-# Config for https://github.com/koekeishiya/skhd/tree/b659b90576cf88100b52ca6ab9270d84af7e579b
+# skhd config — https://github.com/koekeishiya/skhd
+# Regenerated from this `base` file by generator.sh (-> skhdrc.generated).
 
-# # open terminal
+# ── modes ─────────────────────────────────────────────────────────────────────
+# 'resize' mode: enter with (alt - w), use h/j/k/l to resize, esc/return to exit.
+# The active border turns red in resize mode (requires JankyBorders running).
+:: default : borders active_color=0xffffa500 2>/dev/null
+:: resize @ : borders active_color=0xffff3b30 2>/dev/null
+
+# ── don't intercept keys inside these apps (remote desktop / VMs) ─────────────
+.blacklist [
+    "vmware fusion"
+    "parallels desktop"
+    "microsoft remote desktop"
+    "windows app"
+    "screen sharing"
+    "utm"
+]
+
+# ── launchers ──────────────────────────────────────────────────────────────────
+# open terminal
 cmd - return : open -na /System/Applications/Utilities/Terminal.app
-# Open Work profile
+# Chrome work / personal profiles
 alt - z : open -na /Applications/Google\ Chrome.app --args --profile-directory=Profile\ 1
-# Open personal profile
 alt - x : open -na /Applications/Google\ Chrome.app --args --profile-directory=Default
-# alt - z : chrome-cli open "https://smirnov.wiki" -n
 
 # close current window
 alt - q : yabai -m window --close
 
-# # focus window (can jump across displays)
-alt - left : yabai -m window --focus west || yabai -m display --focus west
+# ── focus window (falls back to focusing the display in that direction) ───────
+alt - left  : yabai -m window --focus west  || yabai -m display --focus west
+alt - down  : yabai -m window --focus south
+alt - up    : yabai -m window --focus north
+alt - right : yabai -m window --focus east  || yabai -m display --focus east
 alt + ctrl - d : yabai -m window --focus west || yabai -m display --focus west
-alt - down : yabai -m window --focus south
-alt - up : yabai -m window --focus north
-alt - right : yabai -m window --focus east || yabai -m display --focus east
-alt + ctrl - f: yabai -m window --focus east || yabai -m display --focus east
+alt + ctrl - f : yabai -m window --focus east || yabai -m display --focus east
 
+# ── move / swap windows (can jump displays, not spaces) ───────────────────────
+cmd + shift - left  : yabai -m window --swap west  || $(yabai -m window --display west;  yabai -m display --focus west)
+cmd + shift - down  : yabai -m window --swap south || $(yabai -m window --display south; yabai -m display --focus south)
+cmd + shift - up    : yabai -m window --swap north || $(yabai -m window --display north; yabai -m display --focus north)
+cmd + shift - right : yabai -m window --swap east  || $(yabai -m window --display east;  yabai -m display --focus east)
 
-# # From https://github.com/koekeishiya/yabai/issues/526
-# Move windows around and follow focus. Can jump across displays but not spaces
-cmd + shift - left : yabai -m window --swap west || $(yabai -m window --display west; yabai -m display --focus west)
-cmd + shift - down : yabai -m window --swap south || $(yabai -m window --display south; yabai -m display --focus south)
-cmd + shift - up : yabai -m window --swap north || $(yabai -m window --display north; yabai -m display --focus north)
-cmd + shift - right : yabai -m window --swap east || $(yabai -m window --display east; yabai -m display --focus east)
-
-# # balance size of windows
+# balance sizes / rotate the tree
 alt - space : yabai -m space --balance
+alt - r     : yabai -m space --rotate 90
 
-# # make floating window fill screen
-# shift + cmd - space     : yabai -m window --grid 1:1:0:0:1:1
+# ── resize mode (NEW — keyboard resizing) ─────────────────────────────────────
+alt - w ; resize
+resize < escape ; default
+resize < return ; default
+# the || fallback picks whichever edge this window actually owns in the bsp tree
+resize < h : yabai -m window --resize left:-40:0   || yabai -m window --resize right:-40:0
+resize < l : yabai -m window --resize left:40:0    || yabai -m window --resize right:40:0
+resize < j : yabai -m window --resize bottom:0:40  || yabai -m window --resize top:0:40
+resize < k : yabai -m window --resize bottom:0:-40 || yabai -m window --resize top:0:-40
 
-# # make floating window fill left-half of screen
-# shift + alt - left   : yabai -m window --grid 1:2:0:0:1:1
+# ── stacks (NEW) ──────────────────────────────────────────────────────────────
+# cycle through windows stacked in the same tile
+ctrl + alt - up   : yabai -m window --focus stack.prev
+ctrl + alt - down : yabai -m window --focus stack.next
+# stack the last-focused window onto the current one (build a 2-window stack)
+alt + shift - s   : yabai -m window --stack recent
+# UNSTACK the focused window: float it, then re-tile it back as a normal split.
+# (yabai has no direct un-stack; the float/unfloat cycle removes it from the stack.)
+alt + shift - u   : yabai -m window --toggle float && yabai -m window --toggle float
 
-# # make floating window fill right-half of screen
-# shift + alt - right  : yabai -m window --grid 1:2:1:0:1:1
-
-# create desktop and follow focus
-# Create new display, move window there and follow focus
-cmd + shift - z : yabai -m space --create && \
-                             WIN_ID=$(yabai -m query --windows --window | jq '.id') && \
-                             index="$(yabai -m query --spaces --display | jq 'map(select(."is-native-fullscreen" == false))[-1].index')" && \
-                             yabai -m window --space $index && yabai -m window --focus $WIN_ID
-# Move window to next space
-cmd + shift - x : WIN_ID=$(yabai -m query --windows --window | jq '.id') && \
-                    yabai -m window --space next && yabai -m window --focus $WIN_ID
-
-# # create desktop and follow focus
-alt + shift - n : yabai -m space --create \
-                    index="$(yabai -m query --spaces --display | jq 'map(select(."is-native-fullscreen" == false))[-1].index')" && \
-                    yabai -m window --space $index
-
-# # destroy desktop
-cmd + shift - q : yabai -m space --destroy
-
-# # focus monitor
-ctrl + alt - left  : yabai -m display --focus west
-ctrl + alt - right  : yabai -m display --focus east
-
-# rotate tree (use home row mods - right hand 3rd finger trigger alt)
-alt - r : yabai -m space --rotate 90
-
-
-# # toggle window fullscreen zoom
+# ── fullscreen ────────────────────────────────────────────────────────────────
+# fill the tile, ignoring gaps
 alt - f : yabai -m window --toggle zoom-fullscreen
+# fill the whole display without a native macOS fullscreen space (NEW)
+shift + alt - f : yabai -m window --toggle windowed-fullscreen
+# (native macOS fullscreen alternative: yabai -m window --toggle native-fullscreen)
 
-# # toggle window native fullscreen
-# shift + alt - f : yabai -m window --toggle native-fullscreen
-
-
-# # float / unfloat window and center on screen
-# alt - t : yabai -m window --toggle float;\
-#           yabai -m window --grid 4:4:1:1:2:2
-
-# # toggle sticky
+# toggle sticky (show window on all spaces)
+# NOTE: sticky requires the scripting addition (SA); inert under full SIP.
 alt - s : yabai -m window --toggle sticky
 
+# ── move window between spaces / displays ─────────────────────────────────────
+# move window to the next space and follow it (works with SIP enabled on 7.1.25+)
+cmd + shift - x : WIN_ID=$(yabai -m query --windows --window | jq '.id') && \
+                    yabai -m window --space next && yabai -m window --focus $WIN_ID
+# rotate a window across displays and keep focus on it
+alt + shift - r : WIN_ID=$(yabai -m query --windows --window | jq '.id') && \
+                    yabai -m window --display recent && yabai -m window --focus $WIN_ID
+# focus a monitor directly
+ctrl + alt - left  : yabai -m display --focus west
+ctrl + alt - right : yabai -m display --focus east
 
-# Set insertion point (shows red area whre next window will be placed)
-alt + shift - c : yabai -m window --insert south # down
-alt + shift - v : yabai -m window --insert east # right
+# ── set insertion point (red feedback shows where the next window lands) ──────
+alt + shift - c : yabai -m window --insert south
+alt + shift - v : yabai -m window --insert east
 
-# # Rotate focus between displays and keep focus
-alt + shift -r : WIN_ID=$(yabai -m query --windows --window | jq '.id') && yabai -m window --display recent && yabai -m window --focus $WIN_ID
+# ── space create / destroy — DISABLED ─────────────────────────────────────────
+# space --create / --destroy need the scripting addition (SA) and FAIL under full
+# SIP. Re-enable after partially disabling SIP + loading the SA.
+# cmd + shift - z : yabai -m space --create && \
+#     index="$(yabai -m query --spaces --display | jq 'map(select(."is-native-fullscreen" == false))[-1].index')" && \
+#     yabai -m window --space $index && yabai -m window --focus $(yabai -m query --windows --window | jq '.id')
+# alt + shift - n : yabai -m space --create && \
+#     index="$(yabai -m query --spaces --display | jq 'map(select(."is-native-fullscreen" == false))[-1].index')" && \
+#     yabai -m window --space $index
+# cmd + shift - q : yabai -m space --destroy
+
+# ── application-specific bindings (example, NEW) ──────────────────────────────
+# The same key can do different things per app; `~` forwards the key, `*` = default.
+# alt - n [
+#     "Google Chrome" : open -na "Google Chrome"
+#     "Terminal"       : open -na /System/Applications/Utilities/Terminal.app
+#     *                ~
+# ]
+
+# ── scratchpad toggle (needs a dedicated terminal; see the rule in yabairc) ───
+# alt - 0x32 : yabai -m window --toggle dropdown || open -na Alacritty   # 0x32 = ` key
+
+# ── split config into extra files (example, NEW) ──────────────────────────────
+# .load "skhdrc.local"

--- a/yabai/README.md
+++ b/yabai/README.md
@@ -1,14 +1,137 @@
-# Yabai
+# yabai + skhd — window manager reference
 
-https://github.com/koekeishiya/yabai
+Tiling window manager for macOS: **yabai** (the WM) + **skhd** (hotkeys) + **JankyBorders**
+(`borders`, the active-window highlight). Keybindings are defined in
+[`../skhd/base`](../skhd/base) and compiled to `skhdrc.generated` by
+[`../skhd/generator.sh`](../skhd/generator.sh). yabai settings live in [`yabairc`](yabairc).
 
-## Details
+> **The `asmvik` name is not a mystery:** `asmvik` == `koekeishiya` == **Åsmund Vikane**,
+> the author of yabai (two GitHub handles, same person). Recent yabai rebranded its bundle id
+> `com.koekeishiya.yabai` → `com.asmvik.yabai`, so the launchd service and every
+> `yabai --start/stop/restart-service` command use **`com.asmvik.yabai`**. This is stock and
+> official — not a fork. (skhd is still `com.koekeishiya.skhd`; only yabai was rebranded.)
 
-koekeishiya@ continues his tradition of rewriting window managers for OSX. This
-one is an evolution of chunkwm. It's faster and better in various ways.
-Controlled by the keybinds in skhd.
+## Modifier legend
 
-## Important Notes
+| Symbol | Key |
+|:------:|-----|
+| ⌥ | Option (`alt`) |
+| ⌘ | Command (`cmd`) |
+| ⇧ | Shift (`shift`) |
+| ⌃ | Control (`ctrl`) |
 
-On non-SIP machines, you need to run `sudo _ yabai --install-sa && sudo yabai --load-sa`
-or set up the auto load: https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(latest-release)#macos-big-sur---automatically-load-scripting-addition-on-startup
+## Focus
+
+| Keys | Action |
+|------|--------|
+| ⌥ ← ↓ ↑ → | Focus the window in that direction (← / → fall back to the adjacent display) |
+| ⌥⌃ D / F | Focus window west / east (alternative to the arrows) |
+
+## Move & arrange
+
+| Keys | Action |
+|------|--------|
+| ⌘⇧ ← ↓ ↑ → | Swap window in that direction (or move it to the adjacent display) |
+| ⌥ Space | Balance all windows to equal size |
+| ⌥ R | Rotate the layout tree 90° |
+| ⌥⇧ C | Insertion point **south** — next new window opens *below* (red preview) |
+| ⌥⇧ V | Insertion point **east** — next new window opens to the *right* (red preview) |
+
+## Resize mode
+
+Keyboard resizing lives in its own **mode** so it doesn't consume modifier combos. The
+active-window border turns **red** while you're in it.
+
+| Keys | Action |
+|------|--------|
+| ⌥ W | **Enter** resize mode |
+| H / L | Resize horizontally (40 px steps) |
+| J / K | Resize vertically (40 px steps) |
+| Esc / Return | **Exit** resize mode |
+
+*Each key nudges whichever edge the window actually owns in the split, so one key works no
+matter where the window sits.*
+
+## Stacks
+
+A **stack** piles several windows into one tile (like browser tabs) — only one is visible at a
+time.
+
+| Keys | Action |
+|------|--------|
+| ⌥⇧ S | **Stack** the last-focused window onto the current one |
+| ⌃⌥ ↑ / ↓ | Cycle to the previous / next window in the stack |
+| ⌥⇧ U | **Unstack** the focused window — pop it back out into a normal split |
+
+> **Undoing a stack:** yabai has no direct un-stack command, so ⌥⇧U floats the window and
+> immediately re-tiles it (`--toggle float` twice). That removes it from the stack and
+> re-inserts it as a normal bsp split. Repeat per window to break up a larger stack.
+
+## Fullscreen
+
+| Keys | Action |
+|------|--------|
+| ⌥ F | **Zoom** — fill the current tile, ignoring gaps (still managed) |
+| ⇧⌥ F | **Windowed-fullscreen** — fill the whole display, no native macOS fullscreen space |
+
+## Spaces & displays
+
+| Keys | Action |
+|------|--------|
+| ⌘⇧ X | Move window to the **next space** and follow it |
+| ⌥⇧ R | Move window to the **other display** and keep focus on it |
+| ⌃⌥ ← / → | Focus the display to the west / east |
+
+## Windows & apps
+
+| Keys | Action |
+|------|--------|
+| ⌥ Q | Close the focused window |
+| ⌥ S | Toggle **sticky** (show on all spaces) — *needs the scripting addition; inert under full SIP* |
+| ⌘ Return | Open Terminal |
+| ⌥ Z / ⌥ X | Open Chrome — work / personal profile |
+
+## Mouse (hold **fn**)
+
+| Action | Result |
+|--------|--------|
+| fn + drag | Move window |
+| fn + right-drag | Resize window |
+
+## Managing the services
+
+| Task | Command |
+|------|---------|
+| Restart yabai (reloads `yabairc`) | `yabai --restart-service` |
+| Rebuild + reload skhd after editing `base` | `~/.dotfiles/skhd/generator.sh` |
+| Restart skhd (if `--reload` hits the pid-file bug) | `skhd --restart-service` |
+| Restart borders | `brew services restart borders` |
+
+After editing `skhd/base`, run `generator.sh` — it rebuilds `skhdrc.generated` (the file skhd
+actually reads) and reloads skhd. **Don't edit `skhdrc.generated` directly**; it's overwritten.
+
+`yabairc` is **executed** by yabai at launch, so it must stay executable (`chmod +x`). yabai
+opens its socket *before* running the config, so when scripting a restart, wait on a config
+value (e.g. `window_gap`) rather than just the socket being up.
+
+## Currently disabled (needs the scripting addition)
+
+SIP is fully enabled on this machine, so yabai's scripting addition (SA) can't load. These are
+**commented out** because they'd fail:
+
+- **Create / destroy spaces** (⌘⇧Z, ⌥⇧N, ⌘⇧Q) — need the SA.
+- **Window opacity** and **window animations** — need the SA.
+- **Sticky** (⌥S) — needs the SA (the bind exists but is inert).
+
+To unlock them, partially disable SIP and load the SA (yabai wiki:
+*Installing yabai → Configure scripting addition*). Focus-follows-mouse, resize, stacks, and
+windowed-fullscreen all work **without** it.
+
+## Files
+
+| Path | What |
+|------|------|
+| `yabai/yabairc` | yabai settings — executed at launch; keep it `chmod +x` |
+| `skhd/base` | **source** for keybindings — edit here |
+| `skhd/generator.sh` | rebuilds `skhdrc.generated` from `base` and reloads skhd |
+| `~/.config/borders/bordersrc` | JankyBorders colors (orange active / grey inactive) — *not tracked in dotfiles yet* |

--- a/yabai/yabairc
+++ b/yabai/yabairc
@@ -1,29 +1,41 @@
 #!/usr/bin/env sh
 
-sudo yabai --load-sa
-yabai -m signal --add event=dock_did_restart action="sudo yabai --load-sa"
+# ── Scripting addition (SA) ─────────────────────────────────────────────────
+# DISABLED: `yabai --load-sa` needs partially-disabled SIP + a NOPASSWD sudoers
+# entry. SIP is fully enabled on this machine, so these failed on every launch
+# (sudo: a password is required). Re-enable ONLY after partially disabling SIP —
+# doing so unlocks window animations, opacity, and space create/destroy.
+# sudo yabai --load-sa
+# yabai -m signal --add event=dock_did_restart action="sudo yabai --load-sa"
 
-# global settings
+# ── global settings ─────────────────────────────────────────────────────────
 yabai -m config mouse_follows_focus          off
 yabai -m config focus_follows_mouse          autoraise
+yabai -m config skip_window_focus_animation  on
 yabai -m config window_placement             second_child
-yabai -m config window_topmost               off
-yabai -m config window_opacity               off
 yabai -m config window_shadow                on
-yabai -m config window_border                on
-yabai -m config window_border_width          6
-yabai -m config active_window_border_color   0xffffa500
-yabai -m config normal_window_border_color   0xff505050
-yabai -m config insert_window_border_color   0xffd75f5f
-yabai -m config active_window_opacity        1.0
-yabai -m config normal_window_opacity        0.90
+yabai -m config window_opacity               off
+
+# Insertion-point feedback colour (alt+shift-c / alt+shift-v show where the next
+# window lands). Replaces the removed `insert_window_border_color`.
+yabai -m config insert_feedback_color        0xffd75f5f
+
+# NOTE: yabai's built-in window borders were REMOVED in v6.0.0 — window_border /
+# window_border_width / *_border_color no longer exist. Borders are now the
+# separate JankyBorders tool (`borders`), configured in ~/.config/borders/bordersrc
+# (active 0xffffa500 orange, inactive 0xff505050 grey, width 6 — your old look).
+
+# NOTE: window opacity requires the scripting addition (SA); inert under full SIP:
+# yabai -m config active_window_opacity        1.0
+# yabai -m config normal_window_opacity        0.90
+
 yabai -m config split_ratio                  0.50
 yabai -m config auto_balance                 off
 yabai -m config mouse_modifier               fn
 yabai -m config mouse_action1                move
 yabai -m config mouse_action2                resize
 
-# general space settings
+# ── space / layout settings ─────────────────────────────────────────────────
 yabai -m config layout                       bsp
 yabai -m config top_padding                  32
 yabai -m config bottom_padding               10
@@ -31,45 +43,21 @@ yabai -m config left_padding                 10
 yabai -m config right_padding                10
 yabai -m config window_gap                   10
 
+# ── simple-bar / Übersicht refresh signals ──────────────────────────────────
+# DISABLED: Übersicht is not installed, so these osascript calls errored on every
+# space/window event ("Can't get application id tracesOf.Uebersicht"). Re-enable
+# if you reinstall Übersicht + simple-bar, or migrate to sketchybar.
+# yabai -m signal --add event=space_changed              action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
+# yabai -m signal --add event=display_changed            action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
+# yabai -m signal --add event=window_resized             action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
+# yabai -m signal --add event=window_focused             action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
+# yabai -m signal --add event=application_front_switched action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
+# yabai -m signal --add event=window_destroyed           action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
 
-# performance optimization
-# yabai -m signal --add event=space_changed \
-#     action="osascript -e 'tell application \"Übersicht\" to refresh widget id \"left-jsx\"'"
-# Refresh spaces widget on space change
-yabai -m signal --add event=space_changed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
-# Refresh spaces widget on display focus change
-yabai -m signal --add event=display_changed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
-# Refresh spaces widget on window resize
-yabai -m signal --add event=window_resized action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
-# Refresh process widget on space change
-# yabai -m signal --add event=space_changed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-process-jsx\"'"
-
-# Refresh process widget on when focused application changes
-# yabai -m signal --add event=window_focused action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-process-jsx\"'"
-# Refresh spaces widget on when focused application changes
-yabai -m signal --add event=window_focused action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
-
-# Refresh process widget on when focused application changes
-# yabai -m signal --add event=application_front_switched action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-process-jsx\"'"
-# Refresh spaces widget on when focused application changes
-yabai -m signal --add event=application_front_switched action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
-
-# Refresh process widget on when an application window is closed
-# yabai -m signal --add event=window_destroyed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-process-jsx\"'"
-# Refresh spaces widget on when an application window is closed
-yabai -m signal --add event=window_destroyed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-spaces-jsx\"'"
-
-# Refresh process widget when current window title changes
-# yabai -m signal --add event=window_title_changed action="osascript -e 'tell application id \"tracesOf.Uebersicht\" to refresh widget id \"simple-bar-process-jsx\"'"
-
-
-## Name spaces ##
-# Unused, as I move spaces around all the time
-# yabai -m space 1 --label "1 main"
-# yabai -m space 2 --label "2 productivity"
-# yabai -m space 3 --label "3 messaging"
-# yabai -m space 4 --label "4 project"
-# yabai -m space 5 --label "5 terminal"
-# yabai -m space 6 --label "6 research"
+# ── (optional) scratchpad rule ──────────────────────────────────────────────
+# A scratchpad needs a dedicated single-window terminal. You have Alacritty
+# *dotfiles* but not the app — `brew install --cask alacritty` to use this.
+# Then uncomment (the toggle hotkey lives in skhd):
+# yabai -m rule --add app="^Alacritty$" scratchpad=dropdown grid=6:6:1:1:4:4
 
 echo "yabai configuration loaded.."


### PR DESCRIPTION
## Summary
Refreshes the yabai/skhd window-manager config: enables focus-follows-mouse, adds new actions (resize mode, stacks, windowed-fullscreen), removes settings yabai dropped back in v6, and adds a keybinding reference.

## yabai (`yabai/yabairc`)
- `focus_follows_mouse autoraise` + `skip_window_focus_animation on`
- Removed built-in border settings (removed upstream in v6.0.0 — now handled by JankyBorders) and `window_topmost`
- Commented the inert opacity lines, the failing `sudo yabai --load-sa` (SIP is fully enabled), and the dead Übersicht/simple-bar refresh signals
- Added `insert_feedback_color`

## skhd (`skhd/base`)
- **Resize mode** — `⌥W`, then `h/j/k/l`, `esc` to exit (border turns red)
- **Stacks** — stack (`⌥⇧S`), cycle (`⌃⌥↑/↓`), unstack (`⌥⇧U`)
- **Windowed-fullscreen** — `⇧⌥F`
- `.blacklist` for remote-desktop / VM apps
- Space create/destroy binds disabled (need the scripting addition under full SIP)

## Docs
- `yabai/README.md`: complete keybinding + service-management reference

## Notes
- `skhd/skhdrc.generated` is gitignored (built from `base` by `generator.sh`), so it isn't part of this PR.
- The JankyBorders config lives at `~/.config/borders/bordersrc` and isn't tracked in dotfiles yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
