### PR TITLE
ghostty: per-window processes to dodge NVIDIA GL-surface leak

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -7,3 +7,9 @@ theme = Catppuccin Mocha
 
 # macOS: Option key sends Alt (word-wise motion in zsh/readline). Ignored on Linux.
 macos-option-as-alt = true
+
+# Linux/NVIDIA: don't share one long-lived process across all windows. Ghostty's
+# single-instance process leaks GL surface resources over time and eventually fails
+# new surfaces with error.SystemResources (blank black pane). Per-window processes
+# keep any leak contained to the window it happened in; new windows always start clean.
+gtk-single-instance = false

--- a/i3/profiles/hexane
+++ b/i3/profiles/hexane
@@ -1,8 +1,8 @@
 snippets=(hexane gnome)
 source $ROOT/profiles/_builder
 
-# hexane's terminal is Ghostty. base bakes `set $terminal alacritty` and uses it
-# ($mod+Return binding + autostart) before host snippets are appended, so a second
-# bindsym in the hexane snippet only collides (i3 errors on the duplicate). Rewrite
-# the generated $terminal instead, so base's own binding + autostart resolve to it.
-sed -i 's/^set \$terminal .*/set $terminal ghostty/' $ROOT/config
+# Terminal stays the base default (alacritty). Ghostty was the daily driver here, but
+# on this NVIDIA/X11 box its single-instance process leaks GL surfaces and eventually
+# opens blank (error.SystemResources), so $mod+Return + autostart stay on alacritty.
+# Ghostty is still launchable by name (its config sets gtk-single-instance=false to
+# keep any future leak contained to a single window).


### PR DESCRIPTION
## What
Works around a Ghostty single-instance GL-surface leak on NVIDIA/X11 that eventually opens a blank black pane (`error.SystemResources`).

## Changes
- **`ghostty/config`**: `gtk-single-instance = false` → each window is its own process, so any GL-surface leak stays contained to that window and new windows always start clean.
- **`i3/profiles/hexane`**: revert `$terminal` to the base default (`alacritty`) for `$mod+Return` + autostart, for the same reason. Ghostty is still launchable by name.

Split out of the working tree during a config triage; the hypr Lua migration went out separately in #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)