### PR TITLE
claude: drop stale macOS agentglass notification hook

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -39,14 +39,6 @@
             "command": "notify-send 'Claude Code' 'Needs your attention' --icon=dialog-information --urgency=normal"
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 \"/Users/vania/.config/agentglass/hooks/send_event.py\" --event-type Notification"
-          }
-        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## What
Removes a stale macOS-only agentglass Notification hook from the shared Claude Code settings.

The hook pointed at `/Users/vania/.config/agentglass/hooks/send_event.py` (a macOS path) and is no longer used. Since `claude/settings.json` is a shared dotfile, this removes it on all machines including macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)